### PR TITLE
Karel/lmb 355 burgemeester benoeming

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context.
+
+## How to test
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+
+## Links to other PR's
+
+- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/180

--- a/app.ts
+++ b/app.ts
@@ -1,12 +1,16 @@
 import { app } from 'mu';
-import { ErrorRequestHandler } from 'express';
 import { mandatarissenRouter } from './routes/mandatarissen';
+import express, { ErrorRequestHandler } from 'express';
+import { handleBurgemeesterBenoeming } from './burgemeester-benoeming';
+
+app.use(express.urlencoded({ extended: true }));
 
 app.get('/', async (_req, res) => {
   res.send({ status: 'ok' });
 });
 
 app.use('/mandatarissen', mandatarissenRouter);
+handleBurgemeesterBenoeming(app);
 
 const errorHandler: ErrorRequestHandler = function (err, _req, res, _next) {
   // custom error handler to have a default 500 error code instead of 400 as in the template

--- a/burgemeester-benoeming.ts
+++ b/burgemeester-benoeming.ts
@@ -1,0 +1,517 @@
+import multer from 'multer';
+import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
+import { sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime } from 'mu';
+import { v4 as uuidv4 } from 'uuid';
+import { Request, Response } from 'express';
+import { HttpError } from './util/http-error';
+
+const upload = multer({ dest: '/uploads/' });
+
+const storeFile = async (file, orgGraph) => {
+  const originalFileName = file.originalname;
+  const generatedName = file.filename;
+  const format = file.mimetype;
+  const size = file.size;
+  const extension = file.originalname.split('.').pop();
+  const uuid = uuidv4();
+  const uuidDataObject = uuidv4();
+  const now = sparqlEscapeDateTime(new Date());
+  const fileUri = `http://mu.semte.ch/services/file-service/files/${uuid}`;
+  await updateSudo(`
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        <${fileUri}> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject> ;
+          <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName> "${originalFileName}" ;
+          <http://mu.semte.ch/vocabularies/core/uuid> "${uuid}" ;
+          <http://purl.org/dc/terms/format> "${format}" ;
+          <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize> "${size}"^^xsd:integer ;
+          <http://dbpedia.org/ontology/fileExtension> "${extension}" ;
+          <http://purl.org/dc/terms/created> ${now};
+          <http://purl.org/dc/terms/modified> ${now} .
+        <share://burgemeester-benoemingen/${generatedName}> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject> ;
+          <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> <${fileUri}> ;
+          <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName> "${generatedName}" ;
+          <http://mu.semte.ch/vocabularies/core/uuid> "${uuidDataObject}" ;
+          <http://purl.org/dc/terms/format> "${format}" ;
+          <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize> "${size}"^^xsd:integer ;
+          <http://dbpedia.org/ontology/fileExtension> "${extension}" ;
+          <http://purl.org/dc/terms/created> ${now} ;
+          <http://purl.org/dc/terms/modified> ${now} .
+      }
+    }`);
+  return fileUri;
+};
+
+const checkAuthorization = async (req: Request) => {
+  const authorization = req.get('authorization');
+  if (!authorization) {
+    throw new HttpError('Unauthorized', 401);
+  }
+  const token = authorization.split('Basic ')[1];
+  if (!token) {
+    throw new HttpError('Unauthorized', 401);
+  }
+  const decodedToken = Buffer.from(token, 'base64').toString('utf-8');
+  const [http, username, password] = decodedToken.split(':');
+  const reconstructedUsername = [http, username].join(':');
+
+  const sparql = `
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    SELECT ?vendor WHERE {
+      GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+        ?vendor a foaf:Agent, ext:Vendor ;
+        muAccount:canActOnBehalfOf <http://data.lblod.info/vendors/kalliope> ;
+        muAccount:key ${sparqlEscapeString(password)} .
+        VALUES ?vendor {
+          ${sparqlEscapeUri(reconstructedUsername)}
+        }
+      }
+    } LIMIT 1`;
+
+  const result = await querySudo(sparql);
+  if (result.results.bindings.length == 0) {
+    throw new HttpError('Unauthorized', 401);
+  }
+};
+
+const parseBody = (body) => {
+  if (body == null) {
+    throw new HttpError('No body provided', 400);
+  }
+  const bestuurseenheidUri = body.bestuurseenheidUri;
+  if (!bestuurseenheidUri) {
+    throw new HttpError('No bestuurseenheidUri provided', 400);
+  }
+  const burgemeesterUri = body.burgemeesterUri;
+  if (!burgemeesterUri) {
+    throw new HttpError('No burgemeesterUri provided', 400);
+  }
+  const status = body.status;
+  if (status != 'benoemd' && status != 'afgewezen') {
+    throw new HttpError('Invalid status provided', 400);
+  }
+  const date = body.datum;
+  const parsedDate = new Date(date);
+  if (
+    !date ||
+    parsedDate.getTime() < new Date('2024-10-15T00:00:00.000Z').getTime() ||
+    isNaN(parsedDate.getTime())
+  ) {
+    throw new HttpError('Invalid date provided', 400);
+  }
+  return {
+    bestuurseenheidUri,
+    burgemeesterUri,
+    status,
+    date: parsedDate,
+  } as {
+    bestuurseenheidUri: string;
+    burgemeesterUri: string;
+    status: string;
+    date: Date;
+  };
+};
+
+const findBurgemeesterMandaat = async (
+  bestuurseenheidUri: string,
+  date: Date,
+) => {
+  const sparql = `
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+
+    SELECT DISTINCT ?orgGraph ?mandaatUri WHERE {
+      ?bestuurseenheid a besluit:Bestuurseenheid ;
+        ^besluit:bestuurt ?bestuursOrgaan .
+      VALUES ?bestuurseenheid { ${sparqlEscapeUri(bestuurseenheidUri)} }
+      GRAPH ?orgGraph {
+        ?bestuursOrgaan besluit:classificatie ?classificatie .
+        VALUES ?classificatie {
+          # districtsburgemeester
+          <http://lblod.data.gift/concept-schemes/0887b850-b810-40d4-be0f-cafd01d3259b>
+          # burgemeester
+          <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284>
+        }
+      }
+      FILTER NOT EXISTS {
+        ?orgGraph a <http://mu.semte.ch/vocabularies/ext/FormHistory>
+      }
+      ?bestuursOrgaanIt mandaat:isTijdspecialisatieVan ?bestuursOrgaan .
+      ?bestuursOrgaanIt mandaat:bindingStart ?start .
+      OPTIONAL { ?bestuursOrgaanIt mandaat:bindingEinde ?einde }
+      ?bestuursOrgaanIt org:hasPost ?mandaatUri .
+      ?mandaatUri <http://www.w3.org/ns/org#role> ?code.
+      VALUES ?code {
+        # TODO there is also the 'aangewezen burgemeester' mandate. I believe this should be a status.
+        # if not we probably need to use only that one, but what happens to districtsburgemeesters then?
+        # so many questions
+        # burgemeester
+        <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013>
+        # districtsburgemeester
+        <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d>
+      }
+      FILTER(
+        ?start <= ${sparqlEscapeDateTime(date)} &&
+        (!BOUND(?einde) || ?einde > ${sparqlEscapeDateTime(date)})
+      )
+    }  ORDER BY DESC(?start) LIMIT 1 `;
+  const result = await querySudo(sparql);
+  if (result.results.bindings.length === 0) {
+    throw new HttpError('No burgemeester mandaat found', 400);
+  }
+  return {
+    orgGraph: result.results.bindings[0].orgGraph.value as string,
+    mandaatUri: result.results.bindings[0].mandaatUri.value as string,
+  };
+};
+
+const findExistingMandataris = async (orgGraph, mandaatUri) => {
+  const sparql = `
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+
+    SELECT ?mandataris ?persoon WHERE {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ?mandataris org:holds ?mandaatUri ;
+          mandaat:start ?start ;
+          mandaat:isBestuurlijkeAliasVan ?persoon.
+
+      }
+      VALUES ?mandaatUri { ${sparqlEscapeUri(mandaatUri)} }
+
+    } ORDER BY DESC(?start) LIMIT 1`;
+  const result = await querySudo(sparql);
+  if (result.results.bindings.length === 0) {
+    return null;
+  }
+  return {
+    mandataris: result.results.bindings[0].mandataris.value,
+    persoon: result.results.bindings[0].persoon.value,
+  };
+};
+
+const endExistingMandataris = async (
+  orgGraph: string,
+  mandatarisUri: string,
+  benoemingUri: string,
+  date: Date,
+) => {
+  await updateSudo(`
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    DELETE {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ?mandataris mandaat:einde ?einde .
+      }
+    } INSERT {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ?mandataris mandaat:einde ${sparqlEscapeDateTime(date)} .
+        ?mandataris ext:beeindigdDoor ${sparqlEscapeUri(benoemingUri)} .
+      }
+    } WHERE {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ?mandataris a mandaat:Mandataris .
+        VALUES ?mandataris {
+          ${sparqlEscapeUri(mandatarisUri)}
+        }
+        OPTIONAL {
+          ?mandataris mandaat:einde ?einde .
+        }
+      }
+    }`);
+};
+
+const createBurgemeesterBenoeming = async (
+  bestuurseenheidUri: string,
+  burgemeesterUri: string,
+  status: string,
+  date: Date,
+  file,
+  orgGraph: string,
+) => {
+  const fileUri = await storeFile(file, orgGraph);
+  const uuid = uuidv4();
+  const benoemingUri = `http://mu.semte.ch/vocabularies/ext/burgemeester-benoemingen/${uuid}`;
+  await updateSudo(`
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ${sparqlEscapeUri(benoemingUri)} a ext:BurgemeesterBenoeming ;
+          mu:uuid ${sparqlEscapeString(uuid)} ;
+          ext:status ${sparqlEscapeString(status)} ;
+          ext:datum ${sparqlEscapeDateTime(date)} ;
+          ext:bestuurseenheid ${sparqlEscapeUri(bestuurseenheidUri)} ;
+          ext:burgemeester ${sparqlEscapeUri(burgemeesterUri)} ;
+          ext:file ${sparqlEscapeUri(fileUri)} .
+      }
+    }`);
+  return benoemingUri;
+};
+
+const markCurrentBurgemeesterAsRejected = async (
+  orgGraph: string,
+  burgemeesterUri: string,
+  burgemeesterMandaat: string,
+  benoeming: string,
+) => {
+  const result = await querySudo(`
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+
+    SELECT ?mandataris WHERE {
+      ?mandataris a mandaat:Mandataris ;
+        org:holds ${sparqlEscapeUri(burgemeesterMandaat)} ;
+        mandaat:isBestuurlijkeAliasVan ${sparqlEscapeUri(burgemeesterUri)} ;
+        mandaat:start ?start .
+
+    } ORDER BY DESC(?start) LIMIT 1
+  `);
+
+  if (!result.results.bindings.length) {
+    throw new HttpError('No existing mandataris found for this person', 400);
+  }
+  const mandataris = result.results.bindings[0].mandataris.value;
+  const mandatarisUri = sparqlEscapeUri(mandataris);
+  const benoemingUri = sparqlEscapeUri(benoeming);
+
+  const sparql = `
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ${benoemingUri} ext:rejects ${mandatarisUri} .
+      }
+    }`;
+  await updateSudo(sparql);
+};
+
+const copyFromPreviousMandataris = async (
+  orgGraph: string,
+  existingMandataris: string,
+  date: Date,
+) => {
+  const uuid = uuidv4();
+  const newMandatarisUri = `http://mu.semte.ch/vocabularies/ext/mandatarissen/${uuid}`;
+  await updateSudo(`
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mps: <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/>
+    PREFIX extlmb: <http://mu.semte.ch/vocabularies/ext/lmb/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+    INSERT {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ${sparqlEscapeUri(newMandatarisUri)} a mandaat:Mandataris ;
+          # copy other properties the mandataris might have but not the ones that need editing
+          # this is safe because the mandataris is for the same person and mandate
+          ?p ?o ;
+          mu:uuid ${sparqlEscapeString(uuid)} ;
+          mandaat:start ${sparqlEscapeDateTime(date)} ;
+          # effectief
+          mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> ;
+          # immediately make this status bekrachtigd
+          extlmb:hasPublicationStatus mps:9d8fd14d-95d0-4f5e-b3a5-a56a126227b6.
+      }
+    } WHERE {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ${sparqlEscapeUri(existingMandataris)} a mandaat:Mandataris ;
+          ?p ?o .
+          FILTER (?p NOT IN (mandaat:start, mandaat:status, extlmb:hasPublicationStatus, mu:uuid) )
+      }
+    }`);
+  return newMandatarisUri;
+};
+
+const createBurgemeesterFromScratch = async (
+  orgGraph: string,
+  burgemeesterUri: string,
+  burgemeesterMandaat: string,
+  date: Date,
+  benoeming: string,
+) => {
+  const uuid = uuidv4();
+  const newMandatarisUri = `http://mu.semte.ch/vocabularies/ext/mandatarissen/${uuid}`;
+  const formattedNewMandatarisUri = sparqlEscapeUri(newMandatarisUri);
+  const benoemingUri = sparqlEscapeUri(benoeming);
+  await updateSudo(`
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX mps: <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/>
+    PREFIX extlmb: <http://mu.semte.ch/vocabularies/ext/lmb/>
+    PREFIX org: <http://www.w3.org/ns/org#>
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ${sparqlEscapeUri(newMandatarisUri)} a mandaat:Mandataris ;
+          mu:uuid ${sparqlEscapeString(uuid)} ;
+          org:holds ${sparqlEscapeUri(burgemeesterMandaat)} ;
+          mandaat:isBestuurlijkeAliasVan ${sparqlEscapeUri(burgemeesterUri)} ;
+          mandaat:start ${sparqlEscapeDateTime(date)} ;
+          mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> ;
+          extlmb:hasPublicationStatus mps:9d8fd14d-95d0-4f5e-b3a5-a56a126227b6 .
+        ${benoemingUri} ext:approves ${formattedNewMandatarisUri} .
+      }
+    }`);
+  return newMandatarisUri;
+};
+
+const benoemBurgemeester = async (
+  orgGraph: string,
+  burgemeesterUri: string,
+  burgemeesterMandaat: string,
+  date: Date,
+  benoeming: string,
+  existingMandataris: string | undefined,
+  existingPersoon: string | undefined,
+) => {
+  let newMandatarisUri;
+  if (existingPersoon === burgemeesterUri && existingMandataris) {
+    // we can copy over the existing values for the new burgemeester from the previous mandataris
+    newMandatarisUri = await copyFromPreviousMandataris(
+      orgGraph,
+      existingMandataris,
+      date,
+    );
+  } else {
+    // we need to create a new mandataris from scratch
+    newMandatarisUri = createBurgemeesterFromScratch(
+      orgGraph,
+      burgemeesterUri,
+      burgemeesterMandaat,
+      date,
+      benoeming,
+    );
+  }
+  const benoemingUri = sparqlEscapeUri(benoeming);
+  await updateSudo(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ${benoemingUri} ext:approves ${sparqlEscapeUri(newMandatarisUri)} .
+      }
+    }`);
+};
+
+const confirmKnownPerson = async (orgGraph, personUri) => {
+  const result = await querySudo(`
+    ASK {
+      GRAPH ${sparqlEscapeUri(orgGraph)} {
+        ${sparqlEscapeUri(personUri)} a <http://www.w3.org/ns/person#Person> .
+      }
+    }
+  `);
+  if (!result.boolean) {
+    throw new HttpError('Given person not found', 400);
+  }
+};
+
+const validateAndParseRequest = async (req: Request) => {
+  if (!req.file) {
+    throw new HttpError('No file provided', 400);
+  }
+
+  const parsedBody = parseBody(req.body);
+
+  const { bestuurseenheidUri, burgemeesterUri, status, date } = parsedBody;
+
+  const { orgGraph, mandaatUri: burgemeesterMandaat } =
+    await findBurgemeesterMandaat(bestuurseenheidUri, date);
+
+  await confirmKnownPerson(orgGraph, burgemeesterUri);
+  return {
+    bestuurseenheidUri,
+    burgemeesterUri,
+    status,
+    date,
+    file: req.file,
+    orgGraph,
+    burgemeesterMandaat,
+  };
+};
+
+const onBurgemeesterBenoemingSafe = async (req: Request) => {
+  const {
+    bestuurseenheidUri,
+    burgemeesterUri,
+    status,
+    date,
+    file,
+    orgGraph,
+    burgemeesterMandaat,
+  } = await validateAndParseRequest(req);
+
+  const benoeming = await createBurgemeesterBenoeming(
+    bestuurseenheidUri,
+    burgemeesterUri,
+    status,
+    date,
+    file,
+    orgGraph,
+  );
+  if (status === 'benoemd') {
+    const existing = await findExistingMandataris(
+      orgGraph,
+      burgemeesterMandaat,
+    );
+    await benoemBurgemeester(
+      orgGraph,
+      burgemeesterUri,
+      burgemeesterMandaat,
+      date,
+      benoeming,
+      existing?.mandataris,
+      existing?.persoon,
+    );
+    if (existing) {
+      await endExistingMandataris(
+        orgGraph,
+        existing.mandataris,
+        benoeming,
+        date,
+      );
+    }
+  } else if (status === 'afgewezen') {
+    await markCurrentBurgemeesterAsRejected(
+      orgGraph,
+      burgemeesterUri,
+      burgemeesterMandaat,
+      benoeming,
+    );
+  } else {
+    // this was already checked during validation, just for clarity
+    throw new HttpError('Invalid status provided', 400);
+  }
+};
+
+const onBurgemeesterBenoeming = async (req: Request, res: Response) => {
+  try {
+    await checkAuthorization(req);
+    await onBurgemeesterBenoemingSafe(req);
+    res.status(200).send({ message: 'File uploaded' });
+  } catch (e) {
+    const status = e.status || 500;
+    res.status(status).send({ error: e.message });
+    console.error(`[${status}]: ${e.message}`);
+    console.error(e.stack);
+  }
+};
+
+export const handleBurgemeesterBenoeming = async (app) => {
+  app.post(
+    '/burgemeester-benoeming',
+    upload.single('file'),
+    onBurgemeesterBenoeming,
+  );
+};

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -13,6 +13,7 @@ services:
       - '9225:9229'
     volumes:
       - ../app-lokaal-mandatenbeheer/config/mandataris:/config
+      - ../app-lokaal-mandatenbeheer/data/files/burgemeester-benoemingen:/uploads
       - ./:/app
       # ignore app/dist because this is where we map the built files to, otherwise we get an infinite loop of creating files (on mac)
       - /app/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,12 @@
         "lodash.groupby": "^4.6.0",
         "lodash.uniq": "^4.5.0",
         "moment": "^2.29.1",
+        "multer": "^1.4.5-lts.1",
         "release-it": "^15.4.1",
         "uuid": "^8.3.1"
       },
       "devDependencies": {
+        "@types/node": "^20.12.10",
         "@typescript-eslint/eslint-plugin": "^6.13.2",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
@@ -563,6 +565,15 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "20.12.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
+      "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/semver": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
@@ -1047,6 +1058,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1458,6 +1474,11 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
     "node_modules/bundle-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
@@ -1470,6 +1491,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1662,6 +1694,52 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -4753,6 +4831,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -4776,6 +4865,23 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",
@@ -4912,6 +5018,14 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -5410,6 +5524,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/promise-nodeify": {
       "version": "0.1.0",
@@ -6479,6 +6598,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6822,6 +6949,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -6857,6 +6989,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unique-string": {
       "version": "3.0.0",
@@ -7300,6 +7438,14 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "redpencil.io",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^20.12.10",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
@@ -27,6 +28,7 @@
     "lodash.groupby": "^4.6.0",
     "lodash.uniq": "^4.5.0",
     "moment": "^2.29.1",
+    "multer": "^1.4.5-lts.1",
     "release-it": "^15.4.1",
     "uuid": "^8.3.1"
   }

--- a/util/http-error.ts
+++ b/util/http-error.ts
@@ -1,0 +1,8 @@
+export class HttpError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+  ) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## Description

This adds an api to register burgemeester benoemingen. Currently:
- on rejection it keeps the old burgemeester around but registers the fact that they were rejected (they are still aangewezen, the commune will decide whether to create a new one)
- on ratification, it terminates the old burgemeester and creates a new one with the effectief status and bekrachtigd publication status. The ratification is saved in the datbase
- in both cases, the file is also saved in the database

## How to test

use the postman collection in attachment to reject, then ratify the mayor. Make sure the files can be downloaded and they are linked in the database

[burgemeesterbenoemingen.json](https://github.com/lblod/mandataris-service/files/15272900/burgemeesterbenoemingen.json)

## Linked PRs:

https://github.com/lblod/app-lokaal-mandatenbeheer/pull/136

