### PR TITLE
Ben/lmb 302 upload mandataris csv endpoint

### DIFF
--- a/controllers/mandataris-upload.ts
+++ b/controllers/mandataris-upload.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import readline from 'readline';
+import { HttpError } from '../util/http-error';
+
+export const uploadCsv = (req, res) => {
+  const formData = req.file;
+  if (!formData) {
+    throw new HttpError('No file provided', 400);
+  }
+  const rl = readline.createInterface({
+    input: fs.createReadStream(formData.path),
+    output: process.stdout,
+  });
+  rl.on('line', (line) => {
+    console.log(line);
+  });
+  // Delete file after contents are processed.
+  rl.on('close', () => {
+    fs.unlink(formData.path, (err) => {
+      if (err) {
+        throw new HttpError('File could not be deleted after processing', 500);
+      }
+    });
+  });
+  return res.status(200).send({ status: 'ok' });
+};

--- a/routes/mandatarissen.ts
+++ b/routes/mandatarissen.ts
@@ -30,6 +30,17 @@ mandatarissenRouter.post(
     rl.on('line', (line) => {
       console.log(line);
     });
+    // Delete file after contents are processed.
+    rl.on('close', () => {
+      fs.unlink(formData.path, (err) => {
+        if (err) {
+          throw new HttpError(
+            'File could not be deleted after processing',
+            500,
+          );
+        }
+      });
+    });
     return res.status(200).send({ status: 'ok' });
   },
 );

--- a/routes/mandatarissen.ts
+++ b/routes/mandatarissen.ts
@@ -1,10 +1,8 @@
 import { Request, Response } from 'express';
 import multer from 'multer';
-import fs from 'fs';
-import readline from 'readline';
 import Router from 'express-promise-router';
 import { deleteMandataris } from '../data-access/delete';
-import { HttpError } from '../util/http-error';
+import { uploadCsv } from '../controllers/mandataris-upload';
 
 const upload = multer({ dest: 'mandataris-uploads/' });
 
@@ -19,29 +17,7 @@ mandatarissenRouter.post(
   '/upload-csv',
   upload.single('csv'),
   async (req: Request, res: Response) => {
-    const formData = req.file;
-    if (!formData) {
-      throw new HttpError('No file provided', 400);
-    }
-    const rl = readline.createInterface({
-      input: fs.createReadStream(formData.path),
-      output: process.stdout,
-    });
-    rl.on('line', (line) => {
-      console.log(line);
-    });
-    // Delete file after contents are processed.
-    rl.on('close', () => {
-      fs.unlink(formData.path, (err) => {
-        if (err) {
-          throw new HttpError(
-            'File could not be deleted after processing',
-            500,
-          );
-        }
-      });
-    });
-    return res.status(200).send({ status: 'ok' });
+    uploadCsv(req, res);
   },
 );
 

--- a/routes/mandatarissen.ts
+++ b/routes/mandatarissen.ts
@@ -1,6 +1,11 @@
 import { Request, Response } from 'express';
+import multer from 'multer';
+import fs from 'fs';
 import Router from 'express-promise-router';
 import { deleteMandataris } from '../data-access/delete';
+import { HttpError } from '../util/http-error';
+
+const upload = multer({ dest: 'mandataris-uploads/' });
 
 const mandatarissenRouter = Router();
 
@@ -8,5 +13,21 @@ mandatarissenRouter.delete('/:id', async (req: Request, res: Response) => {
   await deleteMandataris(req.params.id);
   return res.status(204).send();
 });
+
+mandatarissenRouter.post(
+  '/upload-csv',
+  upload.single('csv'),
+  async (req: Request, res: Response) => {
+    const formData = req.file;
+    if (!formData) {
+      throw new HttpError('No file provided', 400);
+    }
+    fs.readFile(formData.path, (err, data) => {
+      if (err) throw new HttpError(err?.message, 400);
+      console.log(data.toString());
+    });
+    return res.status(200).send({ status: 'ok' });
+  },
+);
 
 export { mandatarissenRouter };

--- a/routes/mandatarissen.ts
+++ b/routes/mandatarissen.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import multer from 'multer';
 import fs from 'fs';
+import readline from 'readline';
 import Router from 'express-promise-router';
 import { deleteMandataris } from '../data-access/delete';
 import { HttpError } from '../util/http-error';
@@ -22,9 +23,12 @@ mandatarissenRouter.post(
     if (!formData) {
       throw new HttpError('No file provided', 400);
     }
-    fs.readFile(formData.path, (err, data) => {
-      if (err) throw new HttpError(err?.message, 400);
-      console.log(data.toString());
+    const rl = readline.createInterface({
+      input: fs.createReadStream(formData.path),
+      output: process.stdout,
+    });
+    rl.on('line', (line) => {
+      console.log(line);
     });
     return res.status(200).send({ status: 'ok' });
   },


### PR DESCRIPTION
## Description

Add an endpoint to which you can post csv files.

## How to test

Send a request to http://localhost:90/mandataris-api/mandatarissen/upload-csv with a csv file in the body with the key 'csv', you can do this with bruno or postman, the contents of the csv don't really matter for now.
The service should print the contents of the csv line by line in the console, and return a 200.
