### PR TITLE
create mandataris instances

### DIFF
--- a/data-access/beleidsdomein.ts
+++ b/data-access/beleidsdomein.ts
@@ -1,0 +1,67 @@
+import { sparqlEscapeString, sparqlEscapeUri, query } from 'mu';
+import { v4 as uuidv4 } from 'uuid';
+
+export const ensureBeleidsdomeinen = async (beleidsdomeinen: string[]) => {
+  const existing = await getExistingBeleidsdomeinen(beleidsdomeinen);
+  const missing = beleidsdomeinen.filter((name) => !existing[name]);
+  const created = await createMissingBeleidsdomeinen(missing);
+  return { existing, created };
+};
+
+const getExistingBeleidsdomeinen = async (beleidsdomeinen: string[]) => {
+  const q = `
+  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+  SELECT ?uri ?label WHERE {
+    ?uri a skos:Concept;
+        skos:prefLabel ?label;
+        skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode>.
+    VALUES ?label {
+      ${beleidsdomeinen.map(sparqlEscapeString).join('\n')}
+    }
+  }`;
+
+  const result = await query(q);
+  const mapping: { [key: string]: string } = {};
+  result.results.bindings.forEach((binding) => {
+    mapping[binding.label.value] = binding.uri.value;
+  });
+  return mapping;
+};
+
+const createMissingBeleidsdomeinen = async (beleidsdomeinen: string[]) => {
+  const concepts = beleidsdomeinen.map((name) => {
+    const uuid = uuidv4();
+    const uri = `http://data.vlaanderen.be/id/concept/BeleidsdomeinCode/${uuid}`;
+    return {
+      uri,
+      uuid,
+      name,
+    };
+  });
+
+  const inserts = concepts.map((concept) => {
+    return `${sparqlEscapeUri(concept.uri)} a skos:Concept;
+      mu:uuid ${sparqlEscapeString(concept.uuid)};
+      skos:prefLabel ${sparqlEscapeString(concept.name)};
+      skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode> ;
+      skos:topConceptOf <http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode> .`;
+  });
+
+  const q = `
+  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+  INSERT DATA {
+    GRAPH <http://mu.semte.ch/graphs/application> {
+      ${inserts.join('\n')}
+    }
+  }`;
+  await query(q);
+
+  const mapping: { [key: string]: string } = {};
+  concepts.forEach((concept) => {
+    mapping[concept.name] = concept.uri;
+  });
+  return mapping;
+};

--- a/data-access/persoon.ts
+++ b/data-access/persoon.ts
@@ -66,4 +66,10 @@ export const createPerson = async (
   }`;
 
   await update(q);
+
+  return {
+    uri: uri,
+    voornaam: fName,
+    naam: lName,
+  };
 };

--- a/types.ts
+++ b/types.ts
@@ -3,6 +3,8 @@ export type CsvUploadState = {
   warnings: string[];
   personsCreated: number;
   mandatarissenCreated: number;
+  beleidsdomeinenCreated: number;
+  beleidsDomeinMapping: { [key: string]: string };
 };
 
 export type CSVRow = {
@@ -21,8 +23,8 @@ export type CSVRow = {
 };
 
 export type MandateHit = {
-  mandate: string;
+  mandateUri: string;
   start: string;
   end: string | null;
-  fraction: string | null;
+  fractionUri: string | null;
 };


### PR DESCRIPTION
## Description

Have the mandataris service create instances of mandataris on upload. It will not create a mandataris for the person if a mandataris was found in the same period. It create the link to fractions as well and sets the date for the membership appropriately.

## How to test

Make sure to create the relevant fractions in the 2025-2030 governing period
Use the following file for the upload:
```csv
rrn,firstName,lastName,mandateName,startDateTime,endDateTime,fractieName,rangordeString,beleidsdomeinNames
00000000295,Johnny,New York,,,2030-05-13T11:32:12.038Z,Open VLD,,
00000000097,Jos,Janssens,Schepen,2024-01-01T12:00:12.038Z,2024-12-13T11:32:12.038Z,Open VLD,Eerste schepen,Cultuur|Sport en jeugd|Geitestoet
0000000O988,Georges,Janssens,Schepen,2024-01-01T12:00:12.038Z,2024-12-13T11:32:12.038Z,Open VLD,Tweede schepen,
00000000889,Frans,Janssens,Gemeenteraadslid,2024-01-01T12:00:12.038Z,2030-05-13T11:32:12.038Z,Groen,,
```

This should result in a bunch of errors being reported and at least two mandataris instances being created for the last row:

![image](https://github.com/lblod/mandataris-service/assets/1076194/157e37d0-ef08-4449-9e44-6ddd8d7a1f51)

Be sure to toggle off the filter that hides the inactive mandates as one will be in the future.
