### PR TITLE
Add xsd PREFIX to findBurgemeesterMandaat

### DIFF
--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -128,6 +128,7 @@ const findBurgemeesterMandaat = async (
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
     PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
     PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
     SELECT DISTINCT ?orgGraph ?mandaatUri WHERE {
       ?bestuurseenheid a besluit:Bestuurseenheid ;


### PR DESCRIPTION
## Description

The findBurgemeesterMandaat query seems broken in some instances. I got it to work by adding the missing xsd prefix to the query

## How to test

We will need to deploy to dev to find out if it actually works as expected
