### PR TITLE
LMB-550 | Bug burgemeester benoeming | Cannot call replace on undefined

### DIFF
--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -390,7 +390,7 @@ const benoemBurgemeester = async (
     );
   } else {
     // we need to create a new mandataris from scratch
-    newMandatarisUri = createBurgemeesterFromScratch(
+    newMandatarisUri = await createBurgemeesterFromScratch(
       orgGraph,
       burgemeesterUri,
       burgemeesterMandaat,


### PR DESCRIPTION
## Description

A developer who is wanting to use our endpoint burgemeester-benoeming is getting a statuscode 500 on his call. 

## How to test

1. I ran the debugger and saw that the newMandatarisUri was a promise and so replace cannot be called. Added an await before it and the file uploaded as expected.

