### PR TITLE
LMB-559 | V2 improve error handling burgemeester benoeming

### DIFF
--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -94,8 +94,14 @@ const parseBody = (body) => {
     throw new HttpError('No burgemeesterUri provided', 400);
   }
   const status = body.status;
-  if (status != BENOEMING_STATUS.BENOEMD && status != BENOEMING_STATUS.AFGEWEZEN) {
-    throw new HttpError('Invalid status provided', 400);
+  const possibleStatuses = Object.values(BENOEMING_STATUS);
+  if (!possibleStatuses.includes(status)) {
+    throw new HttpError(
+      `Invalid status provided. Please use the following: ${possibleStatuses.join(
+        ', ',
+      )}`,
+      400,
+    );
   }
   const date = body.datum;
   const parsedDate = new Date(date);
@@ -528,6 +534,6 @@ burgemeesterRouter.post('/', upload.single('file'), onBurgemeesterBenoeming);
 export { burgemeesterRouter };
 
 enum BENOEMING_STATUS {
-  BENOEMD = "benoemd",
-  AFGEWEZEN = 'afgewezen'
+  BENOEMD = 'benoemd',
+  AFGEWEZEN = 'afgewezen',
 }

--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -167,7 +167,10 @@ const findBurgemeesterMandaat = async (
     }  ORDER BY DESC(?start) LIMIT 1 `;
   const result = await querySudo(sparql);
   if (result.results.bindings.length === 0) {
-    throw new HttpError('No burgemeester mandaat found', 400);
+    throw new HttpError(
+      `No burgemeester mandaat found for bestuurseenheid (${bestuurseenheidUri})`,
+      400,
+    );
   }
   return {
     orgGraph: result.results.bindings[0].orgGraph.value as string,
@@ -283,7 +286,10 @@ const markCurrentBurgemeesterAsRejected = async (
   `);
 
   if (!result.results.bindings.length) {
-    throw new HttpError('No existing mandataris found for this person', 400);
+    throw new HttpError(
+      `No existing mandataris found for burgemeester(${burgemeesterUri})`,
+      400,
+    );
   }
   const mandataris = result.results.bindings[0].mandataris.value;
   const mandatarisUri = sparqlEscapeUri(mandataris);
@@ -418,7 +424,7 @@ const confirmKnownPerson = async (orgGraph, personUri) => {
     }
   `);
   if (!result.boolean) {
-    throw new HttpError('Given person not found', 400);
+    throw new HttpError(`Person with uri ${personUri} not found`, 400);
   }
 };
 

--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -94,7 +94,7 @@ const parseBody = (body) => {
     throw new HttpError('No burgemeesterUri provided', 400);
   }
   const status = body.status;
-  if (status != 'benoemd' && status != 'afgewezen') {
+  if (status != BENOEMING_STATUS.BENOEMD && status != BENOEMING_STATUS.AFGEWEZEN) {
     throw new HttpError('Invalid status provided', 400);
   }
   const date = body.datum;
@@ -471,7 +471,7 @@ const onBurgemeesterBenoemingSafe = async (req: Request) => {
     file,
     orgGraph,
   );
-  if (status === 'benoemd') {
+  if (status === BENOEMING_STATUS.BENOEMD) {
     const existing = await findExistingMandataris(
       orgGraph,
       burgemeesterMandaat,
@@ -493,7 +493,7 @@ const onBurgemeesterBenoemingSafe = async (req: Request) => {
         date,
       );
     }
-  } else if (status === 'afgewezen') {
+  } else if (status === BENOEMING_STATUS.AFGEWEZEN) {
     await markCurrentBurgemeesterAsRejected(
       orgGraph,
       burgemeesterUri,
@@ -526,3 +526,8 @@ export const handleBurgemeesterBenoeming = async (app) => {
 burgemeesterRouter.post('/', upload.single('file'), onBurgemeesterBenoeming);
 
 export { burgemeesterRouter };
+
+enum BENOEMING_STATUS {
+  BENOEMD = "benoemd",
+  AFGEWEZEN = 'afgewezen'
+}

--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -1,6 +1,10 @@
 import multer from 'multer';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
-import { sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime } from 'mu';
+import {
+  sparqlEscapeUri,
+  sparqlEscapeString,
+  sparqlEscapeDateTime,
+} from '../util/mu';
 import { v4 as uuidv4 } from 'uuid';
 import { Request, Response } from 'express';
 import { HttpError } from '../util/http-error';

--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -105,12 +105,16 @@ const parseBody = (body) => {
   }
   const date = body.datum;
   const parsedDate = new Date(date);
+  const minAllowedDate = new Date('2024-10-15T00:00:00.000Z');
   if (
     !date ||
-    parsedDate.getTime() < new Date('2024-10-15T00:00:00.000Z').getTime() ||
+    parsedDate.getTime() < minAllowedDate.getTime() ||
     isNaN(parsedDate.getTime())
   ) {
-    throw new HttpError('Invalid date provided', 400);
+    throw new HttpError(
+      `Invalid date provided. Please use a date after ${minAllowedDate.toJSON()}`,
+      400,
+    );
   }
   return {
     bestuurseenheidUri,

--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -11,7 +11,7 @@ const burgemeesterRouter = Router();
 
 const upload = multer({ dest: '/uploads/' });
 
-const storeFile = async (file, orgGraph) => {
+const storeFile = async (file, orgGraph: string) => {
   const originalFileName = file.originalname;
   const generatedName = file.filename;
   const format = file.mimetype;
@@ -188,7 +188,7 @@ const findBurgemeesterMandaat = async (
   };
 };
 
-const findExistingMandataris = async (orgGraph, mandaatUri) => {
+const findExistingMandataris = async (orgGraph: string, mandaatUri: string) => {
   const sparql = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX org: <http://www.w3.org/ns/org#>
@@ -425,7 +425,7 @@ const benoemBurgemeester = async (
     }`);
 };
 
-const confirmKnownPerson = async (orgGraph, personUri) => {
+const confirmKnownPerson = async (orgGraph: string, personUri: string) => {
   const result = await querySudo(`
     ASK {
       GRAPH ${sparqlEscapeUri(orgGraph)} {

--- a/routes/burgemeester-benoeming.ts
+++ b/routes/burgemeester-benoeming.ts
@@ -520,7 +520,9 @@ const onBurgemeesterBenoeming = async (req: Request, res: Response) => {
   try {
     await checkAuthorization(req);
     await onBurgemeesterBenoemingSafe(req);
-    res.status(200).send({ message: 'File uploaded' });
+    res
+      .status(200)
+      .send({ message: `Burgemeester-benoeming: ${req.body.status}` });
   } catch (e) {
     const status = e.status || 500;
     res.status(status).send({ error: e.message });

--- a/util/mu.ts
+++ b/util/mu.ts
@@ -1,0 +1,31 @@
+import {
+  sparqlEscapeUri as mu_sparqlEscapeUri,
+  sparqlEscapeString as mu_sparqlEscapeString,
+  sparqlEscapeDateTime as mu_sparqlEscapeDateTime,
+} from 'mu';
+
+export function sparqlEscapeString(stringValue: string) {
+  if (!stringValue || typeof stringValue !== 'string') {
+    throw Error(
+      `Could not sparql escape string from passed value: ${stringValue}`,
+    );
+  }
+
+  return mu_sparqlEscapeString(stringValue);
+}
+
+export function sparqlEscapeUri(uri: string) {
+  if (!uri || typeof uri !== 'string') {
+    throw Error(`Could not sparql escape uri from passed value: ${uri}`);
+  }
+
+  return mu_sparqlEscapeUri(uri);
+}
+
+export function sparqlEscapeDateTime(date: Date) {
+  if (!date) {
+    throw Error(`Could not sparql escape datetime from passed value: ${date}`);
+  }
+
+  return mu_sparqlEscapeDateTime(date);
+}

--- a/util/mu.ts
+++ b/util/mu.ts
@@ -18,8 +18,9 @@ export function sparqlEscapeUri(uri: string) {
   if (!uri || typeof uri !== 'string') {
     throw Error(`Could not sparql escape uri from passed value: ${uri}`);
   }
+  const cleanUri = uri.replace(/^<|>$/g, '');
 
-  return mu_sparqlEscapeUri(uri);
+  return mu_sparqlEscapeUri(cleanUri);
 }
 
 export function sparqlEscapeDateTime(date: Date) {


### PR DESCRIPTION
## Description

Error warning in burgemeesterbenoemingen are a bit vague. Tell people what is wrong with the input and what valid input would look like.

## How to test

When passing on values that we do not expect a clear error message is shown to the user.

Example of person not existing
![image](https://github.com/lblod/mandataris-service/assets/36266973/2f214996-63e0-4e2d-a440-e94d5bfa6d09)

Example for changed benoeming status
![image](https://github.com/lblod/mandataris-service/assets/36266973/154a3d65-ed67-406c-934e-a93151130d9f)


## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/13
