### PR TITLE
LMB-518 | Extend the cronjob with checking the differences between mandatarissen

### DIFF
--- a/config/custom-dispatching/delta-sync-dispatching.js
+++ b/config/custom-dispatching/delta-sync-dispatching.js
@@ -1,3 +1,6 @@
+const { getDifferenceBetweenSources } = require('./util/mandatarissen');
+const { DIRECT_DATABASE_ENDPOINT } = require('./config');
+
 /**
  * Dispatch the fetched information to a target graph.
  * @param { mu, muAuthSudo, fetch } lib - The provided libraries from the host service.
@@ -13,7 +16,7 @@
  */
 async function dispatch(lib, data) {
   const { termObjectChangeSets } = data;
-
+  console.log(`|> DELTA SYNC`);
   console.log(
     `|> Found an amount of ${termObjectChangeSets.length} changesets`,
   );
@@ -31,6 +34,7 @@ async function dispatch(lib, data) {
         `In graph: ${o.graph}, triple: ${o.subject} ${o.predicate} ${o.object}.`,
     );
     insertStatements.forEach((s) => console.log(s));
+    await getDifferenceBetweenSources(inserts, DIRECT_DATABASE_ENDPOINT);
   }
 }
 

--- a/config/custom-dispatching/initial-sync-dispatching.js
+++ b/config/custom-dispatching/initial-sync-dispatching.js
@@ -1,3 +1,6 @@
+const { getDifferenceBetweenSources } = require('./util/mandatarissen');
+const { DIRECT_DATABASE_ENDPOINT } = require('./config');
+
 /**
  * Dispatch the fetched information to a target graph.
  * @param { mu, muAuthSudo, fech } lib - The provided libraries from the host service.
@@ -13,13 +16,15 @@
  */
 async function dispatch(lib, data) {
   const triples = data.termObjects;
-
+  console.log(`|> INITAL SYNC`);
   console.log(`|> Found ${triples.length} to be processed`);
   console.log('Showing only the first 10.');
   const info = triples
     .slice(0, 10)
     .map((t) => `triple: ${t.subject} ${t.predicate} ${t.object}`);
   info.forEach((s) => console.log(s));
+  await getDifferenceBetweenSources(triples, DIRECT_DATABASE_ENDPOINT);
+
   console.log('All triples were logged');
 }
 

--- a/config/custom-dispatching/util/batch-update.js
+++ b/config/custom-dispatching/util/batch-update.js
@@ -1,0 +1,135 @@
+async function parallelisedBatchedUpdate(
+  lib,
+  nTriples,
+  targetGraph,
+  sleep,
+  batch,
+  extraHeaders,
+  endpoint,
+  operation,
+  directDatabaseEndpoint = '',
+  threads = 1,
+) {
+  const { chunk } = lib;
+
+  const triplesLength = nTriples.length;
+  console.log(`Received ${triplesLength} triples.;
+    ${threads}-parallel batches will be created`);
+
+  const parallelBatches = chunk(nTriples, Math.ceil(triplesLength / threads));
+
+  console.log(`We have ${parallelBatches.length} parallel batches`);
+
+  await Promise.all(
+    parallelBatches.map(async (parallelBatch) => {
+      try {
+        await batchedUpdate(
+          lib,
+          parallelBatch,
+          targetGraph,
+          sleep,
+          batch,
+          extraHeaders,
+          endpoint,
+          operation,
+        );
+        console.log(`|> BATCH DONE`);
+      } catch (e) {
+        console.warn(`Error ${e} ingesting parallel batch.`);
+        // This means we haven't tried directly through virtuoso yet
+        if (directDatabaseEndpoint) {
+          console.warn(`Ingesting through mu-auth failed.
+              Attempt with a direct call to ${directDatabaseEndpoint} this time...`);
+          await batchedUpdate(
+            lib,
+            parallelBatch,
+            targetGraph,
+            sleep,
+            batch,
+            extraHeaders,
+            directDatabaseEndpoint,
+            operation,
+          );
+        } else {
+          console.log(`No options left for updating db; throwing error...`);
+          throw e;
+        }
+      }
+    }),
+  );
+}
+
+async function batchedUpdate(
+  lib,
+  nTriples,
+  targetGraph,
+  sleep,
+  batch,
+  extraHeaders,
+  endpoint,
+  operation,
+) {
+  const { muAuthSudo, chunk, sparqlEscapeUri } = lib;
+  console.log(`Batch size: ${nTriples.length}`);
+
+  const chunkedArray = chunk(nTriples, batch);
+  let chunkCounter = 1;
+
+  for (const chunkedTriple of chunkedArray) {
+    console.log(
+      `Processing chunk number ${chunkCounter} of ${chunkedArray.length} chunks.`,
+    );
+    console.log(`using endpoint from utils ${endpoint}`);
+    try {
+      const updateQuery = `
+        ${operation} DATA {
+           GRAPH ${sparqlEscapeUri(targetGraph)} {
+             ${chunkedTriple.join('')}
+           }
+        }
+      `;
+      console.log(
+        `Hitting database ${endpoint} with batched query \n ${updateQuery}`,
+      );
+      const connectOptions = { sparqlEndpoint: endpoint, mayRetry: true };
+      console.log(
+        'connectOptions: ',
+        connectOptions,
+        'Extra headers: ',
+        extraHeaders,
+      );
+      await muAuthSudo.updateSudo(updateQuery, extraHeaders, connectOptions);
+      console.log(`Sleeping before next query execution: ${sleep}`);
+      await new Promise((r) => setTimeout(r, sleep));
+    } catch (err) {
+      // Binary backoff recovery.
+      console.log('ERROR: ', err);
+      console.log(
+        `Inserting the chunk failed for chunk size ${batch} and ${nTriples.length} triples`,
+      );
+      const smallerBatch = Math.floor(batch / 2);
+      if (smallerBatch === 0) {
+        console.log('the triples that fails: ', nTriples);
+        throw new Error(`Backoff mechanism stops in batched update,
+          we can't work with chunks the size of ${smallerBatch}`);
+      }
+      console.log(`Let's try to ingest wiht chunk size of ${smallerBatch}`);
+      await batchedUpdate(
+        lib,
+        chunkedTriple,
+        targetGraph,
+        sleep,
+        smallerBatch,
+        extraHeaders,
+        endpoint,
+        operation,
+      );
+    }
+    ++chunkCounter;
+  }
+}
+
+module.exports = {
+  batchedUpdate,
+  parallelisedBatchedUpdate,
+};

--- a/config/custom-dispatching/util/mandatarissen.js
+++ b/config/custom-dispatching/util/mandatarissen.js
@@ -1,18 +1,64 @@
-async function getDifferenceBetweenSources(triples, target) {
-  const mappedTriples = triples.map((triple) => {
+const { INGEST_GRAPH } = require('../config');
+
+async function getDifferenceBetweenSources(triples, target, typeUri, lib) {
+  const { muAuthSudo, sparqlEscapeUri } = lib;
+  const uniqueSubjects = Array.from(new Set(triples.map((t) => t.subject)));
+  const subjectsOfTypeQuery = `
+    SELECT ?subject 
+      WHERE {
+        GRAPH ${sparqlEscapeUri(INGEST_GRAPH)} {
+          VALUES ?subject {
+            ${uniqueSubjects.join('\n')}
+          }
+          ?subject a ${sparqlEscapeUri(typeUri)}.
+      }
+    }
+  `;
+  const subjectsOfType = await muAuthSudo.updateSudo(
+    subjectsOfTypeQuery,
+    {},
+    { sparqlEndpoint: target },
+  );
+  if (subjectsOfType.results.bindings.length === 0) {
+    console.log(`|> No subjects for type <${typeUri}> found \n`);
+    return;
+  }
+
+  const mappedResult = subjectsOfType.results.bindings.map((binding) =>
+    sparqlEscapeUri(binding['subject'].value),
+  );
+  const filteredTriplesOfType = triples.filter((triple) =>
+    mappedResult.includes(triple.subject),
+  );
+  const mappedTriples = filteredTriplesOfType.map((triple) => {
     return `(${triple.subject} ${triple.predicate}) \n`;
   });
-
   const query = `
     SELECT ?subject ?predicate ?object
     WHERE {
-      VALUES (?subject ?predicate) { 
+      VALUES (?subject ?predicate) {
         ${mappedTriples.join('')}
       }
       ?subject ?predicate ?object .
     }
   `;
-  console.log(`|> QUERY  FOR DIFFERENCES:\n`, query);
+  const resultsInTarget = await muAuthSudo.updateSudo(
+    query,
+    {},
+    { sparqlEndpoint: target },
+  );
+  const mappedResultsInTarget = resultsInTarget.results.bindings.map(
+    (binding) => {
+      return {
+        subject: binding['subject'].value,
+        predicate: binding['predicate'].value,
+        object: binding['object'].value,
+      };
+    },
+  );
+  console.log(`|> Incoming values: ${JSON.stringify(filteredTriplesOfType)}\n`);
+  console.log(`|> Target values: ${JSON.stringify(mappedResultsInTarget)}\n`);
+  console.log('|> --------------------------');
 }
 
 module.exports = {

--- a/config/custom-dispatching/util/mandatarissen.js
+++ b/config/custom-dispatching/util/mandatarissen.js
@@ -1,0 +1,20 @@
+async function getDifferenceBetweenSources(triples, target) {
+  const mappedTriples = triples.map((triple) => {
+    return `(${triple.subject} ${triple.predicate}) \n`;
+  });
+
+  const query = `
+    SELECT ?subject ?predicate ?object
+    WHERE {
+      VALUES (?subject ?predicate) { 
+        ${mappedTriples.join('')}
+      }
+      ?subject ?predicate ?object .
+    }
+  `;
+  console.log(`|> QUERY  FOR DIFFERENCES:\n`, query);
+}
+
+module.exports = {
+  getDifferenceBetweenSources,
+};

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -36,10 +36,10 @@ services:
       DCR_SYNC_FILES_PATH: '/sync/mandatees-decisions/files'
       DCR_KEEP_DELTA_FILES: true
       DCR_DELTA_FILE_FOLDER: '/deltas/mandatees-decisions/files'
-      DCR_CRON_PATTERN_DELTA_SYNC: '0/15 * * * * *' # Every 15 seconds minute This should be every hour on a running environment
+      DCR_CRON_PATTERN_DELTA_SYNC: '* 0/1 * * *' # Every minute This should be every hour on a running environment
       DCR_DISABLE_INITIAL_SYNC: false
       SLEEP_BETWEEN_BATCHES: 1
-      BATCH_SIZE: 500
+      BATCH_SIZE: 2
       PARALLEL_CALLS: 20
       DCR_WAIT_FOR_INITIAL_SYNC: false
       DIRECT_DATABASE_ENDPOINT: 'http://database:8890/sparql'

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -42,6 +42,7 @@ services:
       BATCH_SIZE: 500
       PARALLEL_CALLS: 20
       DCR_WAIT_FOR_INITIAL_SYNC: false
+      DIRECT_DATABASE_ENDPOINT: 'http://database:8890/sparql'
     networks:
       - debug
       - deltas-sync


### PR DESCRIPTION
## Description

In the dispatch of our consumer we want to check if the incoming mandatees are exitings and have the last updated value. This is in preparation for the next task where we want to process these differences of the mandatees.

## How to test

Run both projects and see the comparison json data in the logs. An example of the logs you can see here.
```bash
mandatees-decisions-1  | |> Incoming values: [{"graph":"<http://redpencil.data.gift/id/deltas/producer/mandatees-decisions>","subject":"<http://data.lblod.info/id/functionarissen/5D5E82FDA3ACB600080002E7>","predicate":"<http://mu.semte.ch/vocabularies/core/uuid>","object":"\"\"\"260543c0-b0c1-11ee-82fe-b92519f8d9a1\"\"\""},{"graph":"<http://redpencil.data.gift/id/deltas/producer/mandatees-decisions>","subject":"<http://data.lblod.info/id/mandatarissen/1daeecd9-eb6d-4e78-9650-2cab4af2f737>","predicate":"<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>","object":"<http://data.vlaanderen.be/ns/mandaat#Mandataris>"}]
mandatees-decisions-1  | 
mandatees-decisions-1  | |> Target values: [{"subject":"http://data.lblod.info/id/mandatarissen/1daeecd9-eb6d-4e78-9650-2cab4af2f737","predicate":"http://www.w3.org/1999/02/22-rdf-syntax-ns#type","object":"http://data.vlaanderen.be/ns/mandaat#Mandataris"},{"subject":"http://data.lblod.info/id/functionarissen/5D5E82FDA3ACB600080002E7","predicate":"http://mu.semte.ch/vocabularies/core/uuid","object":"260543c0-b0c1-11ee-82fe-b92519f8d9a1"}]
mandatees-decisions-1  | 
mandatees-decisions-1  | |> --------------------------
```

When we format the data from the log we get this
```json
// CONSUMER DATA
[
  {
    "graph": "<http://redpencil.data.gift/id/deltas/producer/mandatees-decisions>",
    "subject": "<http://data.lblod.info/id/functionarissen/5D5E82FDA3ACB600080002E7>",
    "predicate": "<http://mu.semte.ch/vocabularies/core/uuid>",
    "object": "\"\"\"260543c0-b0c1-11ee-82fe-b92519f8d9a1\"\"\""
  },
  {
    "graph": "<http://redpencil.data.gift/id/deltas/producer/mandatees-decisions>",
    "subject": "<http://data.lblod.info/id/mandatarissen/1daeecd9-eb6d-4e78-9650-2cab4af2f737>",
    "predicate": "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
    "object": "<http://data.vlaanderen.be/ns/mandaat#Mandataris>"
  }
]
// CURRENT DATABASE VALUES FOR SUBJECT AND PREDICATE
[
  {
    "subject": "http://data.lblod.info/id/mandatarissen/1daeecd9-eb6d-4e78-9650-2cab4af2f737",
    "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
    "object": "http://data.vlaanderen.be/ns/mandaat#Mandataris"
  },
  {
    "subject": "http://data.lblod.info/id/functionarissen/5D5E82FDA3ACB600080002E7",
    "predicate": "http://mu.semte.ch/vocabularies/core/uuid",
    "object": "260543c0-b0c1-11ee-82fe-b92519f8d9a1"
  }
]
```

## Links to other PR's

- https://github.com/JonasVanHoof/mandaten-besluit-consumer-app/pull/6 **=> check this PR first when not approved**
- https://github.com/lblod/mandataris-service/pull/12 **=> check this PR first when not approved**
