### PR TITLE
Ben/lmb 590 copy person

### DIFF
--- a/controllers/mandatees-decisions.ts
+++ b/controllers/mandatees-decisions.ts
@@ -18,7 +18,11 @@ import {
   isSubjectOfType,
   TERM_MANDATARIS_TYPE,
 } from '../data-access/mandatees-decisions';
-import { createPerson } from '../data-access/persoon';
+import {
+  checkPersonExistsAllGraphs,
+  copyPerson,
+  createPerson,
+} from '../data-access/persoon';
 import { mandatarisQueue } from '../routes/mandatees-decisions';
 import { Term } from '../types';
 
@@ -134,7 +138,13 @@ export async function handleTriplesForMandatarisSubject(
     return;
   }
 
-  // TODO Check if person in another graph.
+  // If person exists in another graph, copy that person.
+  const personInOtherGraph =
+    await checkPersonExistsAllGraphs(persoonOfMandataris);
+  if (personInOtherGraph) {
+    await copyPerson(persoonOfMandataris, mandatarisGraph);
+    return;
+  }
 
   // Create new person with given firstname and lastname
   const persoon = await findNameOfPersoonFromStaging(mandatarisSubject);


### PR DESCRIPTION
## Description

If we consume a mandataris from a besluit that has a personUri that is not in the correct graph in the LMB database, but it exists in another graph in LMB, copy over the info to the correct graph.

## How to test

It is a bit difficult to test, but you can test the queries as follows (the queries here are the queries used in the mandataris-service as well). This might be a bit troublesome to test, so if you just thoroughly go throug the code this is fine as well, and then we test this in more detail if the full service is complete. 

1. Create a new person in the OCMW bestuurseenheid and keep that uri, you are going to need to fill in this uri in the following queries under <personUri>.
2. Check if this person indeeds exist with the following query:
```
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
PREFIX person: <http://www.w3.org/ns/person#>
PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX adms: <http://www.w3.org/ns/adms#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
SELECT DISTINCT *
WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18/LoketLB-mandaatGebruiker>{
    <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> a person:Person;
      mu:uuid ?uuid;
      persoon:gebruikteVoornaam ?voornaam;
      adms:identifier ?identifier;
      foaf:familyName ?achternaam.

    ?identifier a adms:Identifier;
      mu:uuid ?idUuid;
      skos:notation ?rrn.

      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> persoon:geslacht ?geslacht.
      }
      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> foaf:name ?altName.
      }
      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> persoon:heeftGeboorte ?geboorte.
        ?geboorte a persoon:Geboorte;
          mu:uuid ?geboorteUuid;
          persoon:datum ?geboorteDatum.
      }
  }
}
```
3. Check if the person does not exist in the gemeente bestuurseenheid:
```
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
PREFIX person: <http://www.w3.org/ns/person#>
PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX adms: <http://www.w3.org/ns/adms#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
SELECT DISTINCT *
WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4/LoketLB-mandaatGebruiker>{
    <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> a person:Person;
      mu:uuid ?uuid;
      persoon:gebruikteVoornaam ?voornaam;
      adms:identifier ?identifier;
      foaf:familyName ?achternaam.

    ?identifier a adms:Identifier;
      mu:uuid ?idUuid;
      skos:notation ?rrn.

      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> persoon:geslacht ?geslacht.
      }
      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> foaf:name ?altName.
      }
      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> persoon:heeftGeboorte ?geboorte.
        ?geboorte a persoon:Geboorte;
          mu:uuid ?geboorteUuid;
          persoon:datum ?geboorteDatum.
      }
  }
}
```
4. This query checks if the person does exist in any graph (except the staging graph), this is used in the PR:
```
PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>

ASK {
  GRAPH ?g {
    <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> ?p ?o.
  }
  FILTER (?g != <http://mu.semte.ch/graphs/besluiten-consumed>).
}
```
5. Execute the copy:
```
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
PREFIX person: <http://www.w3.org/ns/person#>
PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX adms: <http://www.w3.org/ns/adms#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

INSERT {
  GRAPH <http://mu.semte.ch/graphs/organizations/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4/LoketLB-mandaatGebruiker>{
    <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> a person:Person;
      mu:uuid ?uuid;
      persoon:gebruikteVoornaam ?voornaam;
      adms:identifier ?identifier;
      foaf:familyName ?achternaam;
      persoon:geslacht ?geslacht;
      foaf:name ?altName;
      persoon:heeftGeboorte ?geboorte.

    ?identifier a adms:Identifier;
      mu:uuid ?idUuid;
      skos:notation ?rrn.

    ?geboorte a persoon:Geboorte;
      mu:uuid ?geboorteUuid;
      persoon:datum ?geboorteDatum.
  }
}
WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18/LoketLB-mandaatGebruiker>{
    <personUri> a person:Person;
      mu:uuid ?uuid;
      persoon:gebruikteVoornaam ?voornaam;
      adms:identifier ?identifier;
      foaf:familyName ?achternaam.

    ?identifier a adms:Identifier;
      mu:uuid ?idUuid;
      skos:notation ?rrn.

      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> persoon:geslacht ?geslacht.
      }
      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> foaf:name ?altName.
      }
      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> persoon:heeftGeboorte ?geboorte.
        ?geboorte a persoon:Geboorte;
          mu:uuid ?geboorteUuid;
          persoon:datum ?geboorteDatum.
      }
  }
}
```
6. Check if the person does exist in the gemeente bestuurseenheid
```
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
PREFIX person: <http://www.w3.org/ns/person#>
PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX adms: <http://www.w3.org/ns/adms#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
SELECT DISTINCT *
WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4/LoketLB-mandaatGebruiker>{
    <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> a person:Person;
      mu:uuid ?uuid;
      persoon:gebruikteVoornaam ?voornaam;
      adms:identifier ?identifier;
      foaf:familyName ?achternaam.

    ?identifier a adms:Identifier;
      mu:uuid ?idUuid;
      skos:notation ?rrn.

      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> persoon:geslacht ?geslacht.
      }
      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> foaf:name ?altName.
      }
      OPTIONAL {
        <http://data.lblod.info/id/personen/bfbdb056-40d8-4267-a660-4f76f711e92b> persoon:heeftGeboorte ?geboorte.
        ?geboorte a persoon:Geboorte;
          mu:uuid ?geboorteUuid;
          persoon:datum ?geboorteDatum.
      }
  }
}
```
7. Now you can check if the person indeed exists in the frontend as well if you want to.

You can do all these checks with other bestuurseenheden as well, if you start from ocmw Aalst you can just keep the uris in these queries.