### PR TITLE
Ben/lmb 461 nb members bestuursorgaan

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -9,6 +9,7 @@ import { fractiesRouter } from './routes/fractie';
 import { personenRouter } from './routes/persoon';
 import { burgemeesterRouter } from './routes/burgemeester-benoeming';
 import { installatievergaderingRouter } from './routes/intallatievergadering';
+import { mandatenRouter } from './routes/mandaten';
 
 app.use(
   bodyParser.json({
@@ -29,6 +30,7 @@ app.use('/delta', deltaRouter);
 app.use('/mandatarissen', mandatarissenRouter);
 app.use('/fracties', fractiesRouter);
 app.use('/personen', personenRouter);
+app.use('/mandaten', mandatenRouter);
 app.use('/burgemeester-benoeming', burgemeesterRouter);
 app.use('/installatievergadering-api', installatievergaderingRouter);
 

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -12,9 +12,10 @@ export const getNbActiveEffectiveMandatarissen = async (mandaatId: string) => {
     ?mandaat mu:uuid ${sparqlEscapeString(mandaatId)};
         ^org:hasPost ?orgaanInTijd.
     ?mandataris a mandaat:Mandataris;
-        org:holds ?mandaat;
-        # effectief
-        mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> .
+        org:holds ?mandaat.
+    OPTIONAL {
+      ?mandataris mandaat:status ?status.
+    }
     OPTIONAL {
       ?mandataris mandaat:einde ?mandatarisEinde.
     }
@@ -24,6 +25,8 @@ export const getNbActiveEffectiveMandatarissen = async (mandaatId: string) => {
     BIND(IF(BOUND(?orgaanEinde), ?orgaanEinde, ${now}) AS ?actualOrgaanEinde).
     BIND(IF(?actualOrgaanEinde <= ${now}, ?actualOrgaanEinde, ${now}) AS ?testEinde).
     FILTER(!BOUND(?mandatarisEinde) || ?mandatarisEinde >= ?testEinde).
+    # Filter mandatarissen that are either effectief, verhinderd or titelvoerend (or have no status)
+    FILTER(!BOUND(?status) || ?status IN (<http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75>, <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe>, <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3>)).
   }
   `;
 

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -12,7 +12,8 @@ export const getNbActiveMandatarissen = async (mandaatId: string) => {
     ?mandaat mu:uuid ${sparqlEscapeString(mandaatId)};
         ^org:hasPost ?orgaanInTijd.
     ?mandataris a mandaat:Mandataris;
-        org:holds ?mandaat.
+        org:holds ?mandaat;
+        mandaat:isBestuurlijkeAliasVan ?persoon.
     OPTIONAL {
       ?mandataris mandaat:status ?status.
     }

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -6,31 +6,16 @@ export const getNbActiveEffectiveMandatarissen = async (mandaatId: string) => {
   PREFIX org: <http://www.w3.org/ns/org#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 
-  SELECT DISTINCT ?mandataris {
+  SELECT (COUNT(DISTINCT ?mandataris) as ?count) WHERE {
     ?mandaat mu:uuid ${sparqlEscapeString(mandaatId)};
         ^org:hasPost ?orgaanInTijd.
     ?mandataris a mandaat:Mandataris;
-        mandaat:start ?start;
         org:holds ?mandaat;
         # effectief
         mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> .
-    OPTIONAL {
-      ?mandataris mandaat:einde ?end.
-      ?orgaanInTijd mandaat:bindingStart ?orgaanStart;
-        mandaat:bindingEinde ?orgaanEinde.
-      BIND (
-        IF (NOW() > ?orgaanEinde, ?orgaanEinde,
-          IF (NOW() < ?orgaanStart, ?orgaanStart, NOW())
-        ) AS ?date
-      )
-      FILTER (?end >= ?date)
-    }
   }
   `;
 
   const result = await query(q);
-  console.log(result);
-  // if (!result.results.bindings.length) {
-  //   return { mandates: [], graph: null };
-  // }
+  return parseInt(result.results.bindings[0]?.count?.value, 10) || 0;
 };

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -1,0 +1,36 @@
+import { query, sparqlEscapeString } from 'mu';
+
+export const getNbActiveEffectiveMandatarissen = async (mandaatId: string) => {
+  const q = `
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  PREFIX org: <http://www.w3.org/ns/org#>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+  SELECT DISTINCT ?mandataris {
+    ?mandaat mu:uuid ${sparqlEscapeString(mandaatId)};
+        ^org:hasPost ?orgaanInTijd.
+    ?mandataris a mandaat:Mandataris;
+        mandaat:start ?start;
+        org:holds ?mandaat;
+        # effectief
+        mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> .
+    OPTIONAL {
+      ?mandataris mandaat:einde ?end.
+      ?orgaanInTijd mandaat:bindingStart ?orgaanStart;
+        mandaat:bindingEinde ?orgaanEinde.
+      BIND (
+        IF (NOW() > ?orgaanEinde, ?orgaanEinde,
+          IF (NOW() < ?orgaanStart, ?orgaanStart, NOW())
+        ) AS ?date
+      )
+      FILTER (?end >= ?date)
+    }
+  }
+  `;
+
+  const result = await query(q);
+  console.log(result);
+  // if (!result.results.bindings.length) {
+  //   return { mandates: [], graph: null };
+  // }
+};

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -13,6 +13,12 @@ export const getNbActiveEffectiveMandatarissen = async (mandaatId: string) => {
         org:holds ?mandaat;
         # effectief
         mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> .
+    OPTIONAL {
+      ?mandataris mandaat:einde ?mandatarisEinde.
+    }
+    OPTIONAL {
+      ?orgaanInTijd mandaat:bindingEinde ?orgaanEinde.
+    }
   }
   `;
 

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -1,7 +1,7 @@
 import { query, sparqlEscapeString } from 'mu';
 import { sparqlEscapeDateTime } from '../util/mu';
 
-export const getNbActiveEffectiveMandatarissen = async (mandaatId: string) => {
+export const getNbActiveMandatarissen = async (mandaatId: string) => {
   const now = sparqlEscapeDateTime(new Date());
   const q = `
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -26,7 +26,8 @@ export const getNbActiveMandatarissen = async (mandaatId: string) => {
       }
     }
     BIND(IF(BOUND(?orgaanEinde), ?orgaanEinde, ${now}) AS ?actualOrgaanEinde).
-    BIND(IF(?actualOrgaanEinde <= ${now}, ?actualOrgaanEinde, ${now}) AS ?testEinde).
+    # The end of the bestuursperiode is sometimes a day later, so subtract a day to be sure.
+    BIND(IF(?actualOrgaanEinde <= ${now}, ?actualOrgaanEinde - "P1D"^^xsd:duration, ${now}) AS ?testEinde).
     FILTER(!BOUND(?mandatarisEinde) || ?mandatarisEinde >= ?testEinde).
     # Filter mandatarissen that are either effectief, verhinderd or titelvoerend (or have no status)
     FILTER(!BOUND(?status) || ?status IN (<http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75>, <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe>, <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3>)).

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -9,25 +9,30 @@ export const getNbActiveMandatarissen = async (mandaatId: string) => {
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 
   SELECT (COUNT(DISTINCT ?mandataris) as ?count) WHERE {
-    ?mandaat mu:uuid ${sparqlEscapeString(mandaatId)};
-        ^org:hasPost ?orgaanInTijd.
-    ?mandataris a mandaat:Mandataris;
-        org:holds ?mandaat;
-        mandaat:isBestuurlijkeAliasVan ?persoon.
-    OPTIONAL {
-      ?mandataris mandaat:status ?status.
-    }
-    OPTIONAL {
-      ?mandataris mandaat:einde ?mandatarisEinde.
-    }
-    OPTIONAL {
-      ?orgaanInTijd mandaat:bindingEinde ?orgaanEinde.
+    GRAPH ?g {
+      ?mandaat mu:uuid ${sparqlEscapeString(mandaatId)};
+          ^org:hasPost ?orgaanInTijd.
+      ?mandataris a mandaat:Mandataris;
+          org:holds ?mandaat;
+          mandaat:isBestuurlijkeAliasVan ?persoon.
+      OPTIONAL {
+        ?mandataris mandaat:status ?status.
+      }
+      OPTIONAL {
+        ?mandataris mandaat:einde ?mandatarisEinde.
+      }
+      OPTIONAL {
+        ?orgaanInTijd mandaat:bindingEinde ?orgaanEinde.
+      }
     }
     BIND(IF(BOUND(?orgaanEinde), ?orgaanEinde, ${now}) AS ?actualOrgaanEinde).
     BIND(IF(?actualOrgaanEinde <= ${now}, ?actualOrgaanEinde, ${now}) AS ?testEinde).
     FILTER(!BOUND(?mandatarisEinde) || ?mandatarisEinde >= ?testEinde).
     # Filter mandatarissen that are either effectief, verhinderd or titelvoerend (or have no status)
     FILTER(!BOUND(?status) || ?status IN (<http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75>, <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe>, <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3>)).
+    FILTER NOT EXISTS {
+      ?g a <http://mu.semte.ch/vocabularies/ext/FormHistory>
+    }
   }
   `;
 

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -1,6 +1,8 @@
 import { query, sparqlEscapeString } from 'mu';
+import { sparqlEscapeDateTime } from '../util/mu';
 
 export const getNbActiveEffectiveMandatarissen = async (mandaatId: string) => {
+  const now = sparqlEscapeDateTime(new Date());
   const q = `
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
   PREFIX org: <http://www.w3.org/ns/org#>
@@ -19,6 +21,9 @@ export const getNbActiveEffectiveMandatarissen = async (mandaatId: string) => {
     OPTIONAL {
       ?orgaanInTijd mandaat:bindingEinde ?orgaanEinde.
     }
+    BIND(IF(BOUND(?orgaanEinde), ?orgaanEinde, ${now}) AS ?actualOrgaanEinde).
+    BIND(IF(?actualOrgaanEinde <= ${now}, ?actualOrgaanEinde, ${now}) AS ?testEinde).
+    FILTER(!BOUND(?mandatarisEinde) || ?mandatarisEinde >= ?testEinde).
   }
   `;
 

--- a/routes/mandaten.ts
+++ b/routes/mandaten.ts
@@ -1,13 +1,13 @@
 import { Request, Response } from 'express';
 import Router from 'express-promise-router';
-import { getNbActiveEffectiveMandatarissen } from '../data-access/mandaat';
+import { getNbActiveMandatarissen } from '../data-access/mandaat';
 
 const mandatenRouter = Router();
 
 mandatenRouter.get(
   '/nbMembers/:mandaatID',
   async (req: Request, res: Response) => {
-    const nb = await getNbActiveEffectiveMandatarissen(req.params.mandaatID);
+    const nb = await getNbActiveMandatarissen(req.params.mandaatID);
     return res.send({ count: nb });
   },
 );

--- a/routes/mandaten.ts
+++ b/routes/mandaten.ts
@@ -8,7 +8,7 @@ mandatenRouter.get(
   '/nbMembers/:mandaatID',
   async (req: Request, res: Response) => {
     const nb = await getNbActiveEffectiveMandatarissen(req.params.mandaatID);
-    return res.send(nb);
+    return res.send({ count: nb });
   },
 );
 

--- a/routes/mandaten.ts
+++ b/routes/mandaten.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express';
+import Router from 'express-promise-router';
+import { getNbActiveEffectiveMandatarissen } from '../data-access/mandaat';
+
+const mandatenRouter = Router();
+
+mandatenRouter.get(
+  '/nbMembers/:mandaatID',
+  async (req: Request, res: Response) => {
+    const nb = await getNbActiveEffectiveMandatarissen(req.params.mandaatID);
+    return res.send(nb);
+  },
+);
+
+export { mandatenRouter };


### PR DESCRIPTION
## Description

Add a query to get the nb of active mandatarissen of a mandate. This nb is the amount of mandatarissen that are found in the database that are linked to the given mandate, are still active, or were active at the end of a bestuursperiod. And have a status that is equal to effectief, titelvoerend or verhinderd (or have no state).

## How to test

See frontend.

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/276
