### PR TITLE
Ben/lmb 511 aangewezen burgemeester benoeming

### DIFF
--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -122,34 +122,34 @@ const onBurgemeesterBenoemingSafe = async (req: Request) => {
     file,
     orgGraph,
   );
+  const originalMandataris = await findExistingMandatarisOfPerson(
+    orgGraph,
+    aangewezenBurgemeesterMandaat,
+    burgemeesterUri,
+  );
   if (status === BENOEMING_STATUS.BENOEMD) {
-    const mandataris = await findExistingMandatarisOfPerson(
-      orgGraph,
-      aangewezenBurgemeesterMandaat,
-      burgemeesterUri,
-    );
     await benoemBurgemeester(
       orgGraph,
       burgemeesterUri,
       burgemeesterMandaat,
       date,
       benoeming,
-      mandataris,
+      originalMandataris,
     );
-    if (mandataris) {
-      await endExistingMandataris(orgGraph, mandataris, date, benoeming);
-    }
   } else if (status === BENOEMING_STATUS.AFGEWEZEN) {
     await markCurrentBurgemeesterAsRejected(
       orgGraph,
       burgemeesterUri,
-      aangewezenBurgemeesterMandaat,
-      date,
       benoeming,
+      originalMandataris,
     );
   } else {
     // this was already checked during validation, just for clarity
     throw new HttpError('Invalid status provided', 400);
+  }
+  // Both on ratification as rejection, if the mandataris exists, it gets terminated.
+  if (originalMandataris) {
+    await endExistingMandataris(orgGraph, originalMandataris, date, benoeming);
   }
 };
 

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -5,6 +5,7 @@ import {
   benoemBurgemeester,
   createBurgemeesterBenoeming,
   findBurgemeesterMandaat,
+  isBestuurseenheidDistrict,
   markCurrentBurgemeesterAsRejected,
 } from '../data-access/burgemeester';
 import { BENOEMING_STATUS } from '../util/constants';
@@ -71,6 +72,16 @@ const validateAndParseRequest = async (req: Request) => {
   const parsedBody = parseBody(req.body);
 
   const { bestuurseenheidUri, burgemeesterUri, status, date } = parsedBody;
+
+  const isDistrictBestuurseenheid =
+    await isBestuurseenheidDistrict(bestuurseenheidUri);
+
+  if (isDistrictBestuurseenheid) {
+    throw new HttpError(
+      'Ratification of districtsburgemeesters is not yet supported.',
+      400,
+    );
+  }
 
   const { orgGraph, mandaatUri: burgemeesterMandaat } =
     await findBurgemeesterMandaat(bestuurseenheidUri, date);

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -10,10 +10,7 @@ import {
 } from '../data-access/burgemeester';
 import { BENOEMING_STATUS } from '../util/constants';
 import { checkAuthorization } from '../data-access/authorization';
-import {
-  endExistingMandataris,
-  findExistingMandatarisOfPerson,
-} from '../data-access/mandataris';
+import { findExistingMandatarisOfPerson } from '../data-access/mandataris';
 import { personExistsInGraph } from '../data-access/persoon';
 
 const parseBody = (body) => {
@@ -140,16 +137,13 @@ const onBurgemeesterBenoemingSafe = async (req: Request) => {
     await markCurrentBurgemeesterAsRejected(
       orgGraph,
       burgemeesterUri,
+      date,
       benoeming,
       originalMandataris,
     );
   } else {
     // this was already checked during validation, just for clarity
     throw new HttpError('Invalid status provided', 400);
-  }
-  // Both on ratification as rejection, if the mandataris exists, it gets terminated.
-  if (originalMandataris) {
-    await endExistingMandataris(orgGraph, originalMandataris, date, benoeming);
   }
 };
 

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -148,7 +148,8 @@ const onBurgemeesterBenoemingSafe = async (req: Request) => {
     await markCurrentBurgemeesterAsRejected(
       orgGraph,
       burgemeesterUri,
-      burgemeesterMandaat,
+      aangewezenBurgemeesterMandaat,
+      date,
       benoeming,
     );
   } else {

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -75,7 +75,6 @@ const validateAndParseRequest = async (req: Request) => {
 
   const isDistrictBestuurseenheid =
     await isBestuurseenheidDistrict(bestuurseenheidUri);
-
   if (isDistrictBestuurseenheid) {
     throw new HttpError(
       'Ratification of districtsburgemeesters is not yet supported.',
@@ -86,7 +85,11 @@ const validateAndParseRequest = async (req: Request) => {
   const { orgGraph, burgemeesterMandaat, aangewezenBurgemeesterMandaat } =
     await findBurgemeesterMandates(bestuurseenheidUri, date);
 
-  await personExistsInGraph(burgemeesterUri, orgGraph);
+  const personExists = await personExistsInGraph(burgemeesterUri, orgGraph);
+  if (!personExists) {
+    throw new HttpError(`Person with uri ${burgemeesterUri} not found`, 400);
+  }
+
   return {
     bestuurseenheidUri,
     burgemeesterUri,

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -4,7 +4,7 @@ import { HttpError } from '../util/http-error';
 import {
   benoemBurgemeester,
   createBurgemeesterBenoeming,
-  findBurgemeesterMandaat,
+  findBurgemeesterMandates,
   isBestuurseenheidDistrict,
   markCurrentBurgemeesterAsRejected,
 } from '../data-access/burgemeester';
@@ -83,8 +83,8 @@ const validateAndParseRequest = async (req: Request) => {
     );
   }
 
-  const { orgGraph, mandaatUri: burgemeesterMandaat } =
-    await findBurgemeesterMandaat(bestuurseenheidUri, date);
+  const { orgGraph, burgemeesterMandaat, aangewezenBurgemeesterMandaat } =
+    await findBurgemeesterMandates(bestuurseenheidUri, date);
 
   await personExistsInGraph(burgemeesterUri, orgGraph);
   return {
@@ -95,6 +95,7 @@ const validateAndParseRequest = async (req: Request) => {
     file: req.file,
     orgGraph,
     burgemeesterMandaat,
+    aangewezenBurgemeesterMandaat,
   };
 };
 
@@ -107,6 +108,7 @@ const onBurgemeesterBenoemingSafe = async (req: Request) => {
     file,
     orgGraph,
     burgemeesterMandaat,
+    aangewezenBurgemeesterMandaat,
   } = await validateAndParseRequest(req);
 
   const benoeming = await createBurgemeesterBenoeming(

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -12,7 +12,7 @@ import { BENOEMING_STATUS } from '../util/constants';
 import { checkAuthorization } from '../data-access/authorization';
 import {
   endExistingMandataris,
-  findExistingMandataris,
+  findExistingMandatarisOfPerson,
 } from '../data-access/mandataris';
 import { personExistsInGraph } from '../data-access/persoon';
 
@@ -123,9 +123,10 @@ const onBurgemeesterBenoemingSafe = async (req: Request) => {
     orgGraph,
   );
   if (status === BENOEMING_STATUS.BENOEMD) {
-    const existing = await findExistingMandataris(
+    const mandataris = await findExistingMandatarisOfPerson(
       orgGraph,
-      burgemeesterMandaat,
+      aangewezenBurgemeesterMandaat,
+      burgemeesterUri,
     );
     await benoemBurgemeester(
       orgGraph,
@@ -133,16 +134,10 @@ const onBurgemeesterBenoemingSafe = async (req: Request) => {
       burgemeesterMandaat,
       date,
       benoeming,
-      existing?.mandataris?.value,
-      existing?.persoon?.value,
+      mandataris,
     );
-    if (existing) {
-      await endExistingMandataris(
-        orgGraph,
-        existing.mandataris,
-        date,
-        benoeming,
-      );
+    if (mandataris) {
+      await endExistingMandataris(orgGraph, mandataris, date, benoeming);
     }
   } else if (status === BENOEMING_STATUS.AFGEWEZEN) {
     await markCurrentBurgemeesterAsRejected(

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -208,16 +208,16 @@ export const benoemBurgemeester = async (
   burgemeesterMandaat: Term,
   date: Date,
   benoeming: string,
-  existingMandataris: string | undefined,
-  existingPersoon: string | undefined,
+  existingMandataris: Term | null,
 ) => {
   let newMandatarisUri;
-  if (existingPersoon === burgemeesterUri && existingMandataris) {
+  if (existingMandataris) {
     // we can copy over the existing values for the new burgemeester from the previous mandataris
     newMandatarisUri = await copyFromPreviousMandataris(
       orgGraph,
       existingMandataris,
       date,
+      burgemeesterMandaat,
     );
   } else {
     // we need to create a new mandataris from scratch

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -13,7 +13,10 @@ import {
 } from '../util/sparql-result';
 import { Term } from '../types';
 import { sparqlEscapeTermValue } from '../util/sparql-escape';
-import { copyFromPreviousMandataris } from './mandataris';
+import {
+  copyFromPreviousMandataris,
+  endExistingMandataris,
+} from './mandataris';
 
 export async function isBestuurseenheidDistrict(
   bestuurseenheidUri: string,
@@ -123,6 +126,7 @@ export const createBurgemeesterBenoeming = async (
 export const markCurrentBurgemeesterAsRejected = async (
   orgGraph: Term,
   burgemeesterUri: string,
+  date: Date,
   benoeming: string,
   existingMandataris: Term | undefined,
 ) => {
@@ -132,6 +136,8 @@ export const markCurrentBurgemeesterAsRejected = async (
       400,
     );
   }
+
+  await endExistingMandataris(orgGraph, existingMandataris, date, benoeming);
 
   // TODO: check use case if mandataris is waarnemend -> should something happen to the verhindering?
 
@@ -200,6 +206,8 @@ export const benoemBurgemeester = async (
       date,
       burgemeesterMandaat,
     );
+
+    await endExistingMandataris(orgGraph, existingMandataris, date, benoeming);
   } else {
     // we need to create a new mandataris from scratch
     newMandatarisUri = await createBurgemeesterFromScratch(

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -152,7 +152,7 @@ export const markCurrentBurgemeesterAsRejected = async (
   }
 
   endExistingMandataris(orgGraph, result.mandataris, date, benoeming);
-  // TODO: check use case if mandataris is waarnemend
+  // TODO: check use case if mandataris is waarnemend -> should something happen to the verhindering?
 
   const mandatarisUri = sparqlEscapeTermValue(result.mandataris);
   const benoemingUri = sparqlEscapeUri(benoeming);

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -37,7 +37,7 @@ export async function isBestuurseenheidDistrict(
   return getBooleanSparqlResult(result);
 }
 
-export const findBurgemeesterMandaat = async (
+export const findBurgemeesterMandates = async (
   bestuurseenheidUri: string,
   date: Date,
 ) => {
@@ -48,16 +48,14 @@ export const findBurgemeesterMandaat = async (
     PREFIX org: <http://www.w3.org/ns/org#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT DISTINCT ?orgGraph ?mandaatUri WHERE {
+    SELECT DISTINCT ?orgGraph ?burgemeesterMandaat ?aangewezenBurgemeesterMandaat WHERE {
       ?bestuurseenheid a besluit:Bestuurseenheid ;
         ^besluit:bestuurt ?bestuursOrgaan .
       VALUES ?bestuurseenheid { ${sparqlEscapeUri(bestuurseenheidUri)} }
       GRAPH ?orgGraph {
         ?bestuursOrgaan besluit:classificatie ?classificatie .
         VALUES ?classificatie {
-          # districtsburgemeester
-          <http://lblod.data.gift/concept-schemes/0887b850-b810-40d4-be0f-cafd01d3259b>
-          # burgemeester
+          # bestuursorgaan burgemeester
           <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284>
         }
       }
@@ -67,17 +65,10 @@ export const findBurgemeesterMandaat = async (
       ?bestuursOrgaanIt mandaat:isTijdspecialisatieVan ?bestuursOrgaan .
       ?bestuursOrgaanIt mandaat:bindingStart ?start .
       OPTIONAL { ?bestuursOrgaanIt mandaat:bindingEinde ?einde }
-      ?bestuursOrgaanIt org:hasPost ?mandaatUri .
-      ?mandaatUri <http://www.w3.org/ns/org#role> ?code.
-      VALUES ?code {
-        # TODO there is also the 'aangewezen burgemeester' mandate. I believe this should be a status.
-        # if not we probably need to use only that one, but what happens to districtsburgemeesters then?
-        # so many questions
-        # burgemeester
-        <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013>
-        # districtsburgemeester
-        <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d>
-      }
+      ?bestuursOrgaanIt org:hasPost ?burgemeesterMandaat .
+      ?bestuursOrgaanIt org:hasPost ?aangewezenBurgemeesterMandaat .
+      ?burgemeesterMandaat org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013> .
+      ?aangewezenBurgemeesterMandaat org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a>.
       FILTER(
         ?start <= ${sparqlEscapeDateTime(date)} &&
         (!BOUND(?einde) || ?einde > ${sparqlEscapeDateTime(date)})
@@ -93,7 +84,8 @@ export const findBurgemeesterMandaat = async (
   }
   return {
     orgGraph: result.orgGraph,
-    mandaatUri: result.mandaatUri,
+    burgemeesterMandaat: result.burgemeesterMandaat,
+    aangewezenBurgemeesterMandaat: result.aangewezenBurgemeesterMandaat,
   };
 };
 

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -208,7 +208,7 @@ export const benoemBurgemeester = async (
   burgemeesterMandaat: Term,
   date: Date,
   benoeming: string,
-  existingMandataris: Term | null,
+  existingMandataris: Term | undefined | null,
 ) => {
   let newMandatarisUri;
   if (existingMandataris) {

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -7,10 +7,35 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { HttpError } from '../util/http-error';
 import { storeFile } from './file';
-import { findFirstSparqlResult } from '../util/sparql-result';
+import {
+  findFirstSparqlResult,
+  getBooleanSparqlResult,
+} from '../util/sparql-result';
 import { Term } from '../types';
 import { sparqlEscapeTermValue } from '../util/sparql-escape';
 import { copyFromPreviousMandataris } from './mandataris';
+
+export async function isBestuurseenheidDistrict(
+  bestuurseenheidUri: string,
+): Promise<boolean> {
+  const q = `
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+    ASK {
+      GRAPH ?g {
+        ${sparqlEscapeUri(bestuurseenheidUri)} a besluit:Bestuurseenheid ;
+          besluit:classificatie ?classificatie.
+        VALUES ?classificatie {
+          <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003>
+        }
+      }
+    }
+  `;
+  const result = await querySudo(q);
+
+  return getBooleanSparqlResult(result);
+}
 
 export const findBurgemeesterMandaat = async (
   bestuurseenheidUri: string,

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -229,7 +229,7 @@ export const findExistingMandatarisOfPerson = async (
   orgGraph: Term,
   mandaat: Term,
   persoonUri: string,
-) => {
+): Promise<Term | undefined> => {
   const sparql = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX org: <http://www.w3.org/ns/org#>

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -285,7 +285,7 @@ export const copyFromPreviousMandataris = async (
       }
     } WHERE {
       GRAPH ${sparqlEscapeTermValue(orgGraph)} {
-        ${sparqlEscapeUri(existingMandataris)} a mandaat:Mandataris ;
+        ${sparqlEscapeTermValue(existingMandataris)} a mandaat:Mandataris ;
           ?p ?o .
         ${filter}
       }

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -236,10 +236,10 @@ export const findExistingMandatarisOfPerson = async (
 
     SELECT ?mandataris WHERE {
       GRAPH ${sparqlEscapeTermValue(orgGraph)} {
-        ?mandataris org:holds ?mandaatUri ;
+        ?mandataris a mandaat:Mandataris ;
+          org:holds ?mandaatUri ;
           mandaat:start ?start ;
           mandaat:isBestuurlijkeAliasVan ${sparqlEscapeUri(persoonUri)}.
-
       }
       VALUES ?mandaatUri { ${sparqlEscapeTermValue(mandaat)} }
 

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -234,7 +234,7 @@ export const findExistingMandatarisOfPerson = async (
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX org: <http://www.w3.org/ns/org#>
 
-    SELECT ?mandataris ?persoon WHERE {
+    SELECT ?mandataris WHERE {
       GRAPH ${sparqlEscapeTermValue(orgGraph)} {
         ?mandataris org:holds ?mandaatUri ;
           mandaat:start ?start ;

--- a/data-access/persoon.ts
+++ b/data-access/persoon.ts
@@ -6,7 +6,6 @@ import { sparqlEscapeTermValue } from '../util/sparql-escape';
 import { TERM_STAGING_GRAPH } from './mandatees-decisions';
 import { getBooleanSparqlResult } from '../util/sparql-result';
 import { getIdentifierFromPersonUri } from '../util/find-uuid-in-uri';
-import { HttpError } from '../util/http-error';
 
 // note since we use the regular query, not sudo queries, be sure to log in when using this endpoint. E.g. use the vendor login
 

--- a/data-access/persoon.ts
+++ b/data-access/persoon.ts
@@ -84,7 +84,7 @@ export const createPerson = async (
 export const personExistsInGraph = async (
   personUri: string,
   orgGraph: Term,
-) => {
+): Promise<boolean> => {
   const result = await querySudo(`
     ASK {
       GRAPH ${sparqlEscapeTermValue(orgGraph)} {
@@ -92,9 +92,7 @@ export const personExistsInGraph = async (
       }
     }
   `);
-  if (!result.boolean) {
-    throw new HttpError(`Person with uri ${personUri} not found`, 400);
-  }
+  return getBooleanSparqlResult(result);
 };
 
 // All graphs except the staging graph


### PR DESCRIPTION
## Description

Updated the burgemeesterbenoemingen to correctly handle aangewezen burgemeesters.

There are a few different use cases:

1. Rejection: 
- If no aangewezen burgemeester mandataris exists for the given uri, an error is thrown
- I an aangewezen burgemeester mandataris exists for the given uri, the mandataris will be terminated

2. Ratification:
- If no aangewezen burgemeester mandataris exists for the given person uri, a new burgemeester will be created
- If an aangewezen burgemeester mandataris exists for the given person uri, the aangewezen burgemeester is terminated and a new burgemeester uri is created with the same values.

File upload etc. remains unchanged

## How to test

Try to cover the different use cases. The following calls can help you, but you probably want to create an aangewezen burgemeester manually and update the burgemeesterUri and the bestuurseenheidUri

- bruno: [burgemeester-benoemingen-bruno.json](https://github.com/user-attachments/files/16581785/burgemeester-benoemingen-bruno.json)
- postman: [burgemeester-benoemingen-postman.json](https://github.com/user-attachments/files/16581790/burgemeester-benoemingen-postman.json)

## Links to other PR's

- builds on refactor https://github.com/lblod/mandataris-service/pull/35
