### PR TITLE
lmb-698 |  add route to get the decision for the mandataris

### DIFF
--- a/controllers/mandataris.ts
+++ b/controllers/mandataris.ts
@@ -1,6 +1,10 @@
 import { fractie } from '../data-access/fractie';
-import { mandataris } from '../data-access/mandataris';
+import {
+  findDecisionForMandataris,
+  mandataris,
+} from '../data-access/mandataris';
 import { persoon } from '../data-access/persoon';
+import { Term } from '../types';
 
 import { STATUS_CODE } from '../util/constants';
 import { HttpError } from '../util/http-error';
@@ -8,6 +12,7 @@ import { HttpError } from '../util/http-error';
 export const mandatarisUsecase = {
   updateCurrentFractie,
   copyOverNonResourceDomainPredicates,
+  findDecision,
 };
 
 async function updateCurrentFractie(mandatarisId: string): Promise<void> {
@@ -82,4 +87,20 @@ async function copyOverNonResourceDomainPredicates(
     mandatarisId: newMandatarisId,
     itemsAdded: nonDomainResourceProperties.length,
   };
+}
+
+async function findDecision(mandatarisId: string): Promise<string | null> {
+  const isMandataris = await mandataris.isValidId(mandatarisId);
+  if (!isMandataris) {
+    throw new HttpError(
+      `Mandataris with id ${mandatarisId} not found.`,
+      STATUS_CODE.BAD_REQUEST,
+    );
+  }
+  const decision = await findDecisionForMandataris({
+    type: 'uri',
+    value: mandatarisId,
+  } as Term);
+
+  return decision ? decision.value : null;
 }

--- a/routes/mandatarissen.ts
+++ b/routes/mandatarissen.ts
@@ -86,4 +86,24 @@ mandatarissenRouter.put(
   },
 );
 
+mandatarissenRouter.get(
+  '/:id/decision',
+  async (req: Request, res: Response) => {
+    try {
+      const mandatarisId = req.params.id;
+      const foundDecision = await mandatarisUsecase.findDecision(mandatarisId);
+
+      return res.status(STATUS_CODE.OK).send({
+        decisionUri: foundDecision,
+      });
+    } catch (error) {
+      const message =
+        error.message ??
+        `Something went wrong while getting the decision of the mandataris with id: ${req.params.id}.`;
+      const statusCode = error.status ?? STATUS_CODE.INTERNAL_SERVER_ERROR;
+      return res.status(statusCode).send({ message });
+    }
+  },
+);
+
 export { mandatarissenRouter };


### PR DESCRIPTION
## Description

Expose the get decision for mandataris call as a route to be sued in the frontend

## How to test

Use together with the frontend

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/221
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/327
