### PR TITLE
Ben/lmb 932 dont enforce fractie on ocmw

### DIFF
--- a/controllers/linked-mandataris.ts
+++ b/controllers/linked-mandataris.ts
@@ -302,13 +302,6 @@ export const getOrCreateOCMWFractie = async (mandatarisId, graph) => {
     fractie = await getOrCreateOnafhankelijkeFractie(mandatarisId, graph);
   } else {
     fractie = await getFractieOfMandatarisInGraph(mandatarisId, graph);
-
-    if (!fractie) {
-      throw new HttpError(
-        'The given fractie does not exist in the OCMW, it is not possible to create linked mandatarissen in a fractie that exists in the municipality but not in the OCMW.',
-        400,
-      );
-    }
   }
   return fractie;
 };

--- a/controllers/linked-mandataris.ts
+++ b/controllers/linked-mandataris.ts
@@ -179,7 +179,10 @@ export const correctMistakesLinkedMandataris = async (req) => {
     linkedMandataris.uri,
   );
   if (!sameFractie) {
-    const fractie = getOrCreateOCMWFractie(mandatarisId, destinationGraph);
+    const fractie = await getOrCreateOCMWFractie(
+      mandatarisId,
+      destinationGraph,
+    );
 
     await replaceFractieOfMandataris(
       mandatarisId,

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -445,8 +445,10 @@ export async function createNewLinkedMandataris(
   const newMandatarisUuid = uuidv4();
   const newMandatarisUri = `http://data.lblod.info/id/mandatarissen/${newMandatarisUuid}`;
   const escaped = {
+    mandatarisId: sparqlEscapeString(mandatarisId),
     newMandatarisUuid: sparqlEscapeString(newMandatarisUuid),
     newMandataris: sparqlEscapeUri(newMandatarisUri),
+    graph: sparqlEscapeTermValue(graph),
   };
   let fractieTriples = '';
   if (fractie) {
@@ -473,9 +475,9 @@ export async function createNewLinkedMandataris(
     PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
 
     INSERT {
-      GRAPH ${sparqlEscapeTermValue(graph)} {
-        ${sparqlEscapeUri(newMandatarisUri)} a mandaat:Mandataris ;
-          mu:uuid ${sparqlEscapeString(newMandatarisUuid)} ;
+      GRAPH ${escaped.graph} {
+        ${escaped.newMandataris} a mandaat:Mandataris ;
+          mu:uuid ${escaped.newMandatarisUuid} ;
           org:holds ?linkedMandaat ;
           lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07> ;
           ?mandatarisp ?mandatariso .
@@ -485,7 +487,7 @@ export async function createNewLinkedMandataris(
     WHERE {
       GRAPH ?origin {
         ?currentMandataris a mandaat:Mandataris ;
-          mu:uuid ${sparqlEscapeString(mandatarisId)} ;
+          mu:uuid ${escaped.mandatarisId} ;
           org:holds ?currentMandaat ;
           org:hasMembership ?membership ;
           ?mandatarisp ?mandatariso .
@@ -496,7 +498,7 @@ export async function createNewLinkedMandataris(
         ?membership ?memberp ?membero .
       }
 
-      GRAPH ${sparqlEscapeTermValue(graph)} {
+      GRAPH ${escaped.graph} {
         ?linkedMandaat a mandaat:Mandaat ;
           org:role ?linkedBestuursfunctie ;
           ^org:hasPost ?linkedBestuursOrgaanIT .

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -414,9 +414,11 @@ export async function replaceFractieOfMandataris(
         ?ogMembership ?ogMemberP ?ogMemberO .
       }
       GRAPH ${escaped.graph} {
-        ${escaped.linked} a mandaat:Mandataris ;
-          org:hasMembership ?linkedMembership .
-        ?linkedMembership ?linkedMemberP ?linkedMemberO .
+        ${escaped.linked} a mandaat:Mandataris .
+        OPTIONAL {
+          ?currentMandataris org:hasMembership ?linkedMembership .
+          ?linkedMembership ?linkedMemberP ?linkedMemberO .
+        }
       }
 
       FILTER (?ogMemberP NOT IN (mu:uuid, org:organisation))

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -368,27 +368,29 @@ export async function replaceFractieOfMandataris(
   fractie,
   graph,
 ) {
-  const membershipUuid = uuidv4();
-  const membershipUri = `http://data.lblod.info/id/lidmaatschappen/${membershipUuid}`;
-
   const escaped = {
     current: sparqlEscapeString(mandatarisId),
     linked: sparqlEscapeTermValue(linkedMandataris),
-    fractie: sparqlEscapeUri(fractie),
-    membershipUri: sparqlEscapeUri(membershipUri),
-    membershipId: sparqlEscapeString(membershipUuid),
     graph: sparqlEscapeTermValue(graph),
   };
 
   let insertFractieTriples = '';
   if (fractie) {
+    const membershipUuid = uuidv4();
+    const membershipUri = `http://data.lblod.info/id/lidmaatschappen/${membershipUuid}`;
+
+    const escaped2 = {
+      fractie: sparqlEscapeUri(fractie),
+      membershipUri: sparqlEscapeUri(membershipUri),
+      membershipId: sparqlEscapeString(membershipUuid),
+    };
     insertFractieTriples = `
       INSERT {
         GRAPH ${escaped.graph} {
-          ${escaped.linked} org:hasMembership ${escaped.membershipUri} .
-          ${escaped.membershipUri} ?ogMemberP ?ogMemberO ;
-            mu:uuid ${escaped.membershipId} ;
-            org:organisation ${escaped.fractie} .
+          ${escaped.linked} org:hasMembership ${escaped2.membershipUri} .
+          ${escaped2.membershipUri} ?ogMemberP ?ogMemberO ;
+            mu:uuid ${escaped2.membershipId} ;
+            org:organisation ${escaped2.fractie} .
         }
       }
     `;
@@ -442,22 +444,24 @@ export async function createNewLinkedMandataris(
 ) {
   const newMandatarisUuid = uuidv4();
   const newMandatarisUri = `http://data.lblod.info/id/mandatarissen/${newMandatarisUuid}`;
-  const membershipUuid = uuidv4();
-  const membershipUri = `http://data.lblod.info/id/lidmaatschappen/${membershipUuid}`;
   const escaped = {
     newMandatarisUuid: sparqlEscapeString(newMandatarisUuid),
     newMandataris: sparqlEscapeUri(newMandatarisUri),
-    membershipUuid: sparqlEscapeString(membershipUuid),
-    membership: sparqlEscapeUri(membershipUri),
-    fractie: sparqlEscapeUri(fractie),
   };
   let fractieTriples = '';
   if (fractie) {
+    const membershipUuid = uuidv4();
+    const membershipUri = `http://data.lblod.info/id/lidmaatschappen/${membershipUuid}`;
+    const escaped2 = {
+      membershipUuid: sparqlEscapeString(membershipUuid),
+      membership: sparqlEscapeUri(membershipUri),
+      fractie: sparqlEscapeUri(fractie),
+    };
     fractieTriples = `
-      ${escaped.newMandataris} org:hasMembership ${escaped.membership} .
-      ${escaped.membership} ?memberp ?membero ;
-        mu:uuid ${escaped.membershipUuid} ;
-        org:organisation ${sparqlEscapeUri(fractie)} .
+      ${escaped.newMandataris} org:hasMembership ${escaped2.membership} .
+      ${escaped2.membership} ?memberp ?membero ;
+        mu:uuid ${escaped2.membershipUuid} ;
+        org:organisation ${escaped2.fractie} .
     `;
   }
   const q = `


### PR DESCRIPTION
## Description

This just focusses on the not enforcing fracties when you create a linked mandataris. If you create a mandataris in e.g. CBS with a fractie that does not exist in the OCMW, it should now just create the linked mandataris without fractie (before it failed). This should also not give any troubles when updating or correcting a mandataris.

## How to test

Create mandataris in gemeente with a fractie that does not exist in the OCMW, create it's linked mandataris and check if it got created correctly, without copying the fractie. If the fractie does exist, it should properly be taken over. 
