### PR TITLE
lmb-960: date - 10 days to be done with moment js

### DIFF
--- a/controllers/mandataris.ts
+++ b/controllers/mandataris.ts
@@ -179,7 +179,7 @@ export async function handleBulkSetPublicationStatus(
   }
 
   // We just check access to the first mandataris
-  const isMandataris = await mandataris.isValidId(mandatarissen.at(0) ?? '');
+  const isMandataris = await mandataris.isValidId(mandatarissen.at(0));
   if (!isMandataris) {
     throw new HttpError('Unauthorized', 401);
   }

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -1,6 +1,8 @@
 import { CronJob } from 'cron';
 
+import moment from 'moment';
 import { querySudo } from '@lblod/mu-auth-sudo';
+
 import {
   getBooleanSparqlResult,
   getSparqlResults,
@@ -76,9 +78,10 @@ async function HandleEffectieveMandatarissen() {
 }
 
 async function fetchEffectiveMandatarissenWithoutBesluit() {
-  const tenDaysBefore = new Date();
-  tenDaysBefore.setDate(tenDaysBefore.getDate() - 10);
-  const escapedTenDaysBefore = sparqlEscapeDateTime(tenDaysBefore);
+  const momentTenDaysAgo = moment(new Date()).subtract(10, 'days');
+  const escapedTenDaysBefore = sparqlEscapeDateTime(
+    new Date(momentTenDaysAgo.format('YYYY-MM-DD')),
+  );
   const query = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX dct: <http://purl.org/dc/terms/>

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -79,9 +79,7 @@ async function HandleEffectieveMandatarissen() {
 
 async function fetchEffectiveMandatarissenWithoutBesluit() {
   const momentTenDaysAgo = moment(new Date()).subtract(10, 'days');
-  const escapedTenDaysBefore = sparqlEscapeDateTime(
-    new Date(momentTenDaysAgo.format('YYYY-MM-DD')),
-  );
+  const escapedTenDaysBefore = sparqlEscapeDateTime(momentTenDaysAgo.toDate());
   const query = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX dct: <http://purl.org/dc/terms/>


### PR DESCRIPTION
## Description

We want to manipulate dates with the moment library
Check why the notification is send the day after set to effectief

## How to test

1. Check the code that moment is used + date is formatted correctly (see query  in logs of mandataris service)
2. When bulk editing the publication status the effectiefAt triples are updated

## Attachments

**Previous date manipulation works**

![image](https://github.com/user-attachments/assets/c7703de7-280f-407c-9d3b-bb130292503a)

**MomentJS format 
![image](https://github.com/user-attachments/assets/82f69e53-be6d-499e-9e1d-2fdea9c825ff)


**Outgoing query for getting the mandatarissen looks good**
```sparql
.. prefixes
  
    SELECT DISTINCT ?mandataris ?fName ?lName ?bestuursfunctieName ?graph
      WHERE {
        GRAPH ?graph {
          ?mandataris a mandaat:Mandataris ;
            lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188> ;
            mandaat:isBestuurlijkeAliasVan ?person ;
            org:holds / org:role ?bestuursfunctie .
          ?person persoon:gebruikteVoornaam ?fName ;
            foaf:familyName ?lName .
          OPTIONAL {
            ?mandataris lmb:effectiefAt ?effectiefAt .
          }
        }
        ?bestuursfunctie skos:prefLabel ?bestuursfunctieName .
        FILTER NOT EXISTS {
          ?graph a <http://mu.semte.ch/vocabularies/ext/FormHistory>
        }
        FILTER NOT EXISTS {
          ?graph a <http://mu.semte.ch/graphs/public>
        }

        FILTER("2024-10-15T00:00:00.000Z"^^xsd:dateTime >= ?saveEffectiefAt)
        BIND(IF(BOUND(?effectiefAt), ?effectiefAt, "2024-10-15T00:00:00.000Z"^^xsd:dateTime) AS ?saveEffectiefAt).
      }
```

