### PR TITLE
just copy all fracties of iv to ocmw

### DIFF
--- a/routes/installatievergadering.ts
+++ b/routes/installatievergadering.ts
@@ -193,14 +193,13 @@ async function getExistingGemeenteFractions(installatieVergaderingId: string) {
     GRAPH ?origin {
       ?installatieVergadering lmb:heeftBestuursperiode ?period.
       ?installatieVergadering mu:uuid ${escapedId} .
-      ?bestuursorgaan ext:origineleBestuursorgaan ?realOrg.
       ?bestuursorgaan mandaat:isTijdspecialisatieVan ?org.
+      ?bestuursorgaan lmb:heeftBestuursperiode ?period.
       ?fractie org:memberOf ?bestuursorgaan.
       ?fractie regorg:legalName ?name.
       OPTIONAL {
         ?fractie ext:isFractietype ?type.
       }
-      ?bestuursorgaan lmb:heeftBestuursperiode ?period.
     }
     FILTER NOT EXISTS {
       ?origin a <http://mu.semte.ch/vocabularies/ext/FormHistory>


### PR DESCRIPTION
## Description

Only fracties, that were linked to the fake bestuursorganen, were copied when installatievergadering was finished and the mandatees of the ocmw got moved to the bestuurseenheid ocmw. This was no longer possible, since these fracties now have the link to the correct bestuursorganen (needed for GN).

## How to test

Create some ocmw mandatees in the prepare iv, finish the iv and see if all are copied, both mandatees as fracties.