### PR TITLE
lmb-1073: when email not found return null

### DIFF
--- a/data-access/bestuurseenheid.ts
+++ b/data-access/bestuurseenheid.ts
@@ -74,5 +74,5 @@ async function getContactEmailFromMandataris(mandatarisUri: string) {
   const sparqlResult = await querySudo(query);
   const result = findFirstSparqlResult(sparqlResult);
 
-  return result?.email.value;
+  return result?.email?.value;
 }


### PR DESCRIPTION
## Description

Got this error in the service. Make it return null when not found.

```
mandataris-1  |       ?bestuursorgaanInTijd mandaat:isTijdspecialisatieVan ?bestuursorgaan .
mandataris-1  |       ?bestuursorgaanInTijd org:hasPost ?mandaat .
mandataris-1  |
mandataris-1  |       OPTIONAL {
mandataris-1  |         ?contact a ext:BestuurseenheidContact ;
mandataris-1  |           ext:contactVoor ?bestuurseenheid ;
mandataris-1  |           schema:email ?email .
mandataris-1  |       }
mandataris-1  |     } LIMIT 1
mandataris-1  |
mandataris-1  | Headers set on SPARQL client: {"requestDefaults":{"headers":{"mu-auth-sudo":"true"}}}
mandataris-1  | /usr/src/build/data-access/bestuurseenheid.js:71
mandataris-1  |   return result?.email.value;
```

## How to test

Look at the code

