### PR TITLE
send bekrachtigingsmails in bulk

### DIFF
--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -3,18 +3,14 @@ import { CronJob } from 'cron';
 import moment from 'moment';
 import { querySudo } from '@lblod/mu-auth-sudo';
 
-import {
-  findFirstSparqlResult,
-  getBooleanSparqlResult,
-  getSparqlResults,
-} from '../util/sparql-result';
+import { findFirstSparqlResult, getSparqlResults } from '../util/sparql-result';
 import { PUBLICATION_STATUS } from '../util/constants';
 import {
   sparqlEscapeDateTime,
   sparqlEscapeString,
   sparqlEscapeUri,
 } from '../util/mu';
-import { createNotification } from '../util/create-notification';
+import { createBulkNotificationMandatarissenWithoutBesluit } from '../util/create-notification';
 import {
   SEND_EMAILS,
   sendMissingBekrachtigingsmail,
@@ -45,21 +41,10 @@ async function handleEffectieveMandatarissen() {
   const mandatarissen =
     await fetchEffectiveMandatarissenWithoutBesluitAndNotification();
 
-  // TODO Create notification for all mandatarissen
-  // setTimeout(async () => {
-  //   await createNotification({
-  //     title: SUBJECT,
-  //     description: `De publicatie status van ${mandataris.name} met mandaat ${mandataris.mandate} staat al 10 dagen of meer op effectief zonder dat er een besluit is toegevoegd. Gelieve deze mandataris manueel te bekrachtigen en een besluit toe te voegen of publiceer het besluit van de installatievergadering via een notuleringspakket.`,
-  //     type: 'warning',
-  //     graph: mandataris.graph,
-  //     links: [
-  //       {
-  //         type: 'mandataris',
-  //         uri: mandataris.uri,
-  //       },
-  //     ],
-  //   });
-  // }, bufferTime);
+  await createBulkNotificationMandatarissenWithoutBesluit(
+    SUBJECT,
+    mandatarissen,
+  );
 
   // TODO send emails per bestuurseenheid
   // if (SEND_EMAILS) {

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -46,18 +46,25 @@ async function handleEffectieveMandatarissen() {
     mandatarissen,
   );
 
-  // TODO send emails per bestuurseenheid
-  // if (SEND_EMAILS) {
-  //   const email = await getContactEmailForMandataris(
-  //     mandatarissenWithoutNotification.at(0)?.uri,
-  //   );
-  //   if (email) {
-  //     await sendMissingBekrachtigingsmail(
-  //       email,
-  //       mandatarissenWithoutNotification,
-  //     );
-  //   }
-  // }
+  if (SEND_EMAILS) {
+    const grouped_mandatarissen = mandatarissen.reduce((acc, mandataris) => {
+      const { graph } = mandataris;
+      if (!acc[graph]) {
+        acc[graph] = [];
+      }
+      acc[graph].push(mandataris);
+      return acc;
+    }, {});
+    for (const key in grouped_mandatarissen) {
+      const mandataris_group = grouped_mandatarissen[key];
+      const email = await getContactEmailForMandataris(
+        mandataris_group.at(0)?.uri,
+      );
+      if (email) {
+        await sendMissingBekrachtigingsmail(email, mandataris_group);
+      }
+    }
+  }
   running = false;
 }
 

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -51,14 +51,16 @@ async function handleEffectieveMandatarissen() {
     mandate: string;
     graph: string;
   }[] = [];
-  for (const mandataris of mandatarissen) {
+  const promises = mandatarissen.map(async (mandataris) => {
     const hasNotification = await hasNotificationForMandataris(
       mandataris.uri,
       mandataris.graph,
     );
     if (hasNotification) {
-      continue;
+      return Promise.resolve();
     }
+
+    mandatarissenWithoutNotification.push(mandataris);
 
     setTimeout(async () => {
       await createNotification({
@@ -73,10 +75,11 @@ async function handleEffectieveMandatarissen() {
           },
         ],
       });
-
-      mandatarissenWithoutNotification.push(mandataris);
     }, bufferTime);
-  }
+  });
+
+  await Promise.all(promises);
+
   if (SEND_EMAILS) {
     const email = await getContactEmailForMandataris(
       mandatarissenWithoutNotification.at(0)?.uri,

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -143,6 +143,7 @@ async function fetchEffectiveMandatarissenWithoutBesluitAndNotification() {
         BIND(IF(BOUND(?effectiefAt), ?effectiefAt, ${escapedTenDaysBefore}) AS ?saveEffectiefAt).
         FILTER(${escapedTenDaysBefore} >= ?saveEffectiefAt)
       }
+      ORDER BY ?bestuursfunctieName ?lName
   `;
 
   const sparqlResult = await querySudo(query);

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -136,11 +136,12 @@ async function fetchEffectiveMandatarissenWithoutBesluitAndNotification() {
             ?mandataris lmb:effectiefAt ?effectiefAt .
           }
 
-          ?notification a ext:SystemNotification;
-            dct:subject ${sparqlEscapeString(SUBJECT)};
-            ext:notificationLink ?notificationLink.
-
-          ?notificationLink ext:linkedTo ?mandataris.
+          FILTER NOT EXISTS {
+            ?notification a ext:SystemNotification;
+              dct:subject ${sparqlEscapeString(SUBJECT)};
+              ext:notificationLink ?notificationLink.
+            ?notificationLink ext:linkedTo ?mandataris.
+          }
         }
         ?bestuursfunctie skos:prefLabel ?bestuursfunctieName .
         ?graph ext:ownedBy ?owningEenheid.

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -15,12 +15,35 @@ console.log(
 );
 console.log(`SEND_EMAIL_FOR_MANDATARIS_EFFECTIEF SET TO: ${SEND_EMAILS}`);
 
-export async function sendMailTo(emailTo: string, mandataris) {
+export async function sendMissingBekrachtigingsmail(
+  emailTo: string,
+  mandatarissen,
+) {
+  if (mandatarissen.length == 0) {
+    return;
+  }
+  let mandatarisTable = '';
+  for (const mandataris of mandatarissen) {
+    mandatarisTable += `
+      <tr>
+        <td>${mandataris.name}</td>
+        <td>${mandataris.mandate}</td>
+      </tr>
+    `;
+  }
   const from = sparqlEscapeString(EMAIL_FROM_MANDATARIS_EFFECTIEF as string);
   const to = sparqlEscapeString(emailTo);
   const htmlMessage = `
     <p>Beste,</p>
-    <p>De mandataris ${mandataris.name} met mandaat ${mandataris.mandate} heeft al meer dan 10 dagen de publicatiestatus ‘Effectief’ zonder koppeling met een besluit.</p>
+    <p>Er zijn een aantal mandatarissen die al meer dan 10 dagen de publicatiestatus ‘Effectief’ hebben zonder koppeling met een besluit. Voor uw gemeente zijn dit er ${mandatarissen.length}.</p>
+    <p> Hieronder vindt u een overzicht van al deze mandatarissen: <p>
+    <table>
+      <tr>
+        <th>Naam</th>
+        <th>Mandaat</th>
+      </tr>
+      ${mandatarisTable}
+    </table>
     <p>Gelieve het besluit te koppelen.</p>
     <br/>
     <p>Met vriendelijke groeten,</p>

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -26,8 +26,8 @@ export async function sendMissingBekrachtigingsmail(
   for (const mandataris of mandatarissen) {
     mandatarisTable += `
       <tr>
-        <td>${mandataris.name}</td>
-        <td>${mandataris.mandate}</td>
+        <td style="padding: 8px">${mandataris.name}</td>
+        <td style="padding: 8px">${mandataris.mandate}</td>
       </tr>
     `;
   }
@@ -39,8 +39,8 @@ export async function sendMissingBekrachtigingsmail(
     <p> Hieronder vindt u een overzicht van al deze mandatarissen: <p>
     <table>
       <tr>
-        <th>Naam</th>
-        <th>Mandaat</th>
+        <th style="text-align:left;padding:8px">Naam</th>
+        <th style="text-align:left;padding:8px">Mandaat</th>
       </tr>
       ${mandatarisTable}
     </table>

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -19,12 +19,12 @@ export async function sendMissingBekrachtigingsmail(
   emailTo: string,
   mandatarissen,
 ) {
-  if (mandatarissen.length == 0) {
+  if (mandatarissen.length === 0) {
     return;
   }
-  let mandatarisTable = '';
+  let mandatarisRows = '';
   for (const mandataris of mandatarissen) {
-    mandatarisTable += `
+    mandatarisRows += `
       <tr>
         <td style="padding: 8px">${mandataris.name}</td>
         <td style="padding: 8px">${mandataris.mandate}</td>
@@ -42,7 +42,7 @@ export async function sendMissingBekrachtigingsmail(
         <th style="text-align:left;padding:8px">Naam</th>
         <th style="text-align:left;padding:8px">Mandaat</th>
       </tr>
-      ${mandatarisTable}
+      ${mandatarisRows}
     </table>
     <p>Gelieve het besluit te koppelen.</p>
     <br/>

--- a/util/create-notification.ts
+++ b/util/create-notification.ts
@@ -27,7 +27,6 @@ export async function createNotification({
   graph: string;
   links: notificationLink[];
 }) {
-  console.log(`Notification created: ${title}, ${JSON.stringify(links)}`);
   const id = uuid();
   const uri = sparqlEscapeUri(
     `http://data.lblod.info/id/SystemNotification/${id}`,
@@ -63,6 +62,7 @@ export async function createNotification({
       }
     }`;
   await updateSudo(query);
+  console.log(`Notification created: ${title}, ${JSON.stringify(links)}`);
 }
 
 export const createMandatarisBesluitNotification = async ({
@@ -118,12 +118,6 @@ export async function createBulkNotificationMandatarissenWithoutBesluit(
   title: string,
   mandatarissen,
 ) {
-  console.log(
-    `Bulk notification created for mandatarissen: ${title}, ${mandatarissen
-      .map((mandataris) => mandataris.uri)
-      .join(', ')}`,
-  );
-
   const data = mandatarissen
     .map((mandataris) => {
       const notificationId = uuid();
@@ -163,4 +157,9 @@ export async function createBulkNotificationMandatarissenWithoutBesluit(
       ${data}
     }`;
   await updateSudo(query);
+  console.log(
+    `Bulk notification created for mandatarissen: ${title}, ${mandatarissen
+      .map((mandataris) => mandataris.uri)
+      .join(', ')}`,
+  );
 }

--- a/util/create-notification.ts
+++ b/util/create-notification.ts
@@ -113,3 +113,54 @@ export async function getMandatarisNotificationGraph(mandataris: string) {
   }
   return result.results.bindings[0].graph.value;
 }
+
+export async function createBulkNotificationMandatarissenWithoutBesluit(
+  title: string,
+  mandatarissen,
+) {
+  console.log(
+    `Bulk notification created for mandatarissen: ${title}, ${mandatarissen
+      .map((mandataris) => mandataris.uri)
+      .join(', ')}`,
+  );
+
+  const data = mandatarissen
+    .map((mandataris) => {
+      const notificationId = uuid();
+      const notification = sparqlEscapeUri(
+        `http://data.lblod.info/id/SystemNotification/${notificationId}`,
+      );
+      const linkId = uuid();
+      const link = sparqlEscapeUri(
+        `http://data.lblod.info/id/SystemNotificationLink/${linkId}`,
+      );
+      const description = `De publicatie status van ${mandataris.name} met mandaat ${mandataris.mandate} staat al 10 dagen of meer op effectief zonder dat er een besluit is toegevoegd. Gelieve deze mandataris manueel te bekrachtigen en een besluit toe te voegen of publiceer het besluit van de installatievergadering via een notuleringspakket.`;
+
+      return `
+        GRAPH ${sparqlEscapeUri(mandataris.graph)} {
+          ${notification} a ext:SystemNotification ;
+            mu:uuid ${sparqlEscapeString(notificationId)} ;
+            dct:subject ${sparqlEscapeString(title)} ;
+            schema:description ${sparqlEscapeString(description)} ;
+            dct:created ${sparqlEscapeDateTime(new Date())} ;
+            dct:type ${sparqlEscapeUri(notificationTypes['warning'])} ;
+            ext:notificationLink ${link} .
+          ${link} a ext:SystemNotificationLink ;
+            mu:uuid ${sparqlEscapeString(linkId)} ;
+            ext:linkedType ${sparqlEscapeString('mandataris')} ;
+            ext:linkedTo ${sparqlEscapeUri(mandataris.uri)} .
+        }
+      `;
+    })
+    .join('\n');
+
+  const query = `
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX schema: <http://schema.org/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    INSERT DATA {
+      ${data}
+    }`;
+  await updateSudo(query);
+}


### PR DESCRIPTION
## Description

Group bekrachtigingsmails per bestuurseenheid.
Also reduced the number of database queries for this logic. 

## How to test

Few remarks:
There are some huge triples that need to be written, which might fail with the current tag of the database, best is to use the image `image: semtech/sparql-parser:0.0.12`.
You need to up the app with the profile=send-emails
Put the following in your docker-compose.override.yml in the app not sure you need it, but better safe than sorry:
```
 deliver-email:
    environment:
      WELL_KNOWN_SERVICE: "test"
      EMAIL_FROM_MANDATARIS_EFFECTIEF: "lokaalmandatenbeheer@vlaanderen.be" 
      SEND_EMAIL_FOR_MANDATARIS_EFFECTIEF: true
```
Put the following in the override of the mandataris-service:
```
services:
  mandataris:
    restart: always
    environment:
      NOTIFICATION_CRON_PATTERN: "* * * * *" # Every hour on the hour
      SEND_EMAIL_FOR_MANDATARIS_EFFECTIEF: true
```

Actual testing:
There are two ways to test, either you start with a pretty recent dump of production as new data/db, this should trigger some instances which have been effective for a while without besluit
I would advice to put on the debugger and loop through the code in the mandataris-service and see it makes sense what it does.
Then you need to put on the logs of the deliver-email in the app, this should tell you something like this: 
```
Email 1: URI = http://data.lblod.info/id/emails/cae0af5b-fd3c-4a66-92f2-60b2cb7c6c1c
deliver-email-1  | Email 1: Email moved to sentbox
deliver-email-1  | Email 1: Email message ID updated
deliver-email-1  | Email 1: MessageId updated from  to <674da5aa-a988-94bb-4785-b3b816155134@address.com>
deliver-email-1  | Email 1: Preview URL https://ethereal.email/message/Z1bgNQRyEEepVcs1Z1g1ORGrZFbQEjaAAAAADAzknJCYUTFPW6joYDhh4zA
```
Which you can then check.

The other option requires a bit more work. You go to a bestuurseenheid. Finish the IV and then write a migration to reset the lmb:effectiefAt of the mandatarissen to something longer than 10 days ago. The rest remains the same. This way you can also check the notifications in the frontend.