### PR TITLE
fetch bekrachtigingen from files on harvester service and process them directly, disable old decision processing

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -12,7 +12,6 @@ import { installatievergaderingRouter } from './routes/installatievergadering';
 import { mandatenRouter } from './routes/mandaten';
 import { mockRouter } from './routes/mock';
 
-import { cronjob as notificationBekrachtigdMandataris } from './cron/notification-for-bekrachtigde-mandataris';
 import { cronjob as harvestBekrachtigingenCron } from './cron/fetch-bekrachtigingen';
 import { electionResultsRouter } from './routes/verkiezingsresultaten';
 

--- a/app.ts
+++ b/app.ts
@@ -11,9 +11,9 @@ import { burgemeesterRouter } from './routes/burgemeester-benoeming';
 import { installatievergaderingRouter } from './routes/installatievergadering';
 import { mandatenRouter } from './routes/mandaten';
 import { mockRouter } from './routes/mock';
-import { cronjob } from './cron/handle-decision-queue';
 
 import { cronjob as notificationBekrachtigdMandataris } from './cron/notification-for-bekrachtigde-mandataris';
+import { cronjob as harvestBekrachtigingenCron } from './cron/fetch-bekrachtigingen';
 import { electionResultsRouter } from './routes/verkiezingsresultaten';
 
 app.use(
@@ -53,4 +53,5 @@ app.use(errorHandler);
 
 //FIXME disable notifications for now
 //notificationBekrachtigdMandataris.start();
-cronjob.start();
+// FIXME disabled handling of decision queue because the publications are broken right now. Reactivate when we have decent publications again
+harvestBekrachtigingenCron.start();

--- a/cron/fetch-bekrachtigingen.ts
+++ b/cron/fetch-bekrachtigingen.ts
@@ -114,6 +114,7 @@ async function processCurrentBekrachtigingen() {
   INSERT {
     GRAPH ${sparqlEscapeUri(bekrachtigingGraph)} {
       ?besluit mandaat:bekrachtigtAanstellingVan ?mandataris.
+      ?besluit <http://www.w3.org/ns/prov#wasDerivedFrom> ?besluitOrigin.
       ?besluit ext:autoHarvested ?true.
     }
     GRAPH ?g {
@@ -123,6 +124,7 @@ async function processCurrentBekrachtigingen() {
   } WHERE {
     GRAPH ${sparqlEscapeUri(receiverGraph)} {
       ?besluit ext:targets ?mandataris.
+      ?besluit <http://www.w3.org/ns/prov#wasDerivedFrom> ?besluitOrigin.
     }
     GRAPH ?g {
       ?mandataris a mandaat:Mandataris.

--- a/cron/fetch-bekrachtigingen.ts
+++ b/cron/fetch-bekrachtigingen.ts
@@ -1,0 +1,185 @@
+import { CronJob } from 'cron';
+import { updateSudo as update, querySudo } from '@lblod/mu-auth-sudo';
+import { sparqlEscapeUri, sparqlEscapeString } from 'mu';
+import { getIdentifierFromUri } from '../util/uuid-for-uri';
+import { v4 as uuidv4 } from 'uuid';
+
+const HARVEST_CRON_PATTERN = process.env.HARVEST_CRON_PATTERN || '0 * * * *'; // Every hour
+
+const receiverGraph = 'http://mu.semte.ch/graphs/besluit-bekrachtigingen';
+const bekrachtigingGraph = 'http://mu.semte.ch/graphs/besluiten-consumed';
+
+async function processBekrachtigingen() {
+  const harvesters = [
+    'https://lokaalbeslist-harvester-0.s.redhost.be',
+    'https://lokaalbeslist-harvester-1.s.redhost.be',
+    'https://lokaalbeslist-harvester-2.s.redhost.be',
+    'https://lokaalbeslist-harvester-3.s.redhost.be',
+  ];
+
+  for (const harvester of harvesters) {
+    await processBekrachtigingenForHarvester(harvester).catch((e) => {
+      console.log(
+        `Error processing bekrachtigingen for harvester ${harvester}: ${e.message}`,
+      );
+    });
+  }
+  await addMissingUuidsAndTypes();
+}
+
+async function processBekrachtigingenForHarvester(harvester: string) {
+  await fetchBekrachtigingenForHarvester(harvester);
+  await processCurrentBekrachtigingen();
+}
+
+async function fetchBekrachtigingenForHarvester(harvester: string) {
+  const path = '/assets/exports/export-bekrachtigingen.ttl';
+  const ttldata = await fetch(`${harvester}${path}`).then((res) => {
+    if (res.status >= 400) {
+      throw new Error(
+        'Error fetching bekrachtigingen, status code: ' + res.status,
+      );
+    }
+    return res.text();
+  });
+
+  await update(`DELETE {
+    GRAPH ${sparqlEscapeUri(receiverGraph)} {
+      ?s ?p ?o.
+    }
+  } WHERE {
+    GRAPH ${sparqlEscapeUri(receiverGraph)} {
+      ?s ?p ?o.
+    }
+  }`);
+
+  const batchedTtlData = ttldata.split('> .\n');
+  while (batchedTtlData.length > 0) {
+    const batch = batchedTtlData.splice(0, 1000).join('> .\n');
+    const suffix = batchedTtlData.length > 0 ? '> .\n' : '';
+    await update(`
+    INSERT DATA {
+       GRAPH ${sparqlEscapeUri(receiverGraph)} {
+          ${batch}${suffix}
+       }
+    }`);
+  }
+}
+
+async function processCurrentBekrachtigingen() {
+  await update(`
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  PREFIX org: <http://www.w3.org/ns/org#>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  DELETE {
+    GRAPH ?g {
+      ?mandataris lmb:hasPublicationStatus ?status.
+      ?mandataris dct:modified ?modified.
+    }
+  }
+  INSERT {
+    GRAPH ${sparqlEscapeUri(bekrachtigingGraph)} {
+      ?besluit mandaat:bekrachtigtAanstellingVan ?mandataris.
+      ?besluit ext:autoHarvested ?true.
+    }
+    GRAPH ?g {
+      ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6>.
+      ?mandataris dct:modified ?now.
+    }
+  } WHERE {
+    GRAPH ${sparqlEscapeUri(receiverGraph)} {
+      ?besluit ext:forRole ?role.
+      ?besluit ext:bekrachtigtMandatarissenVoor ?orgInT.
+    }
+    GRAPH ?g {
+      ?mandataris a mandaat:Mandataris.
+      ?mandataris org:holds / org:role ?role.
+      ?mandataris org:holds / ^org:hasPost ?trueOrgInT.
+      ?orgInT lmb:heeftBestuursperiode ?periode.
+      ?trueOrgInT lmb:heeftBestuursperiode ?periode.
+      ?orgInT mandaat:isTijdspecialisatieVan / besluit:bestuurt / ^besluit:bestuurt / ^mandaat:isTijdspecialisatieVan ?trueOrgInT.
+      FILTER NOT EXISTS {
+        ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6> .
+      }
+      OPTIONAL {
+        ?mandataris dct:modified ?modified.
+      }
+      OPTIONAL {
+        ?mandataris lmb:hasPublicationStatus ?status.
+      }
+    }
+    ?g ext:ownedBy ?someone.
+    BIND(NOW() as ?now)
+  }
+  `);
+}
+
+async function addMissingUuidsAndTypes() {
+  const query = `
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT ?besluit WHERE {
+    GRAPH ${sparqlEscapeUri(bekrachtigingGraph)} {
+      ?besluit mandaat:bekrachtigtAanstellingVan ?mandataris.
+    }
+    FILTER NOT EXISTS {
+      ?besluit mu:uuid ?id.
+    }
+  }`;
+  const results = await querySudo(query);
+  const newUuids = results.results.bindings.map((binding) => {
+    const uri = binding.besluit.value;
+    let id = getIdentifierFromUri(uri);
+    if (!id) {
+      id = uuidv4();
+    }
+    return { uri, id };
+  });
+
+  const triplesToInsert = newUuids
+    .map(
+      ({ uri, id }) =>
+        `${sparqlEscapeUri(uri)} mu:uuid ${sparqlEscapeString(id)} .`,
+    )
+    .join('\n');
+  const updateUuids = `
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(bekrachtigingGraph)} {
+        ${triplesToInsert}
+      }
+    }
+  `;
+  await update(updateUuids);
+  await update(`
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  INSERT {
+    GRAPH ${sparqlEscapeUri(bekrachtigingGraph)} {
+      ?besluit a besluit:Besluit.
+    }
+  } WHERE {
+    GRAPH ${sparqlEscapeUri(bekrachtigingGraph)} {
+      ?besluit mandaat:bekrachtigtAanstellingVan ?mandataris.
+    }
+  }`);
+}
+
+let running = false;
+export const cronjob = CronJob.from({
+  cronTime: HARVEST_CRON_PATTERN,
+  onTick: async () => {
+    console.log(
+      'DEBUG: Starting cronjob to send notifications for effective mandatees without besluit.',
+    );
+    if (running) {
+      return;
+    }
+    running = true;
+    await processBekrachtigingen();
+    running = false;
+  },
+});

--- a/util/uuid-for-uri.ts
+++ b/util/uuid-for-uri.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { sparqlEscapeUri } from 'mu';
 import { querySudo } from '@lblod/mu-auth-sudo';
 
-function getIdentifierFromUri(uri: string) {
+export function getIdentifierFromUri(uri: string) {
   const uuid = uri.split('/').pop();
   if (
     uuid &&


### PR DESCRIPTION
## Description

This uses files produced by the harvesters to fetch decision data and processes them directly instead of using the delta consumer because the regular data harvested is too low in quality.
## How to test

Run this on production data, afterwards, you should see bekrachtigde mandatarissen in multiple eenheden, e.g. zuienkerke: gemeenteraad (voorzitter & lid), schepenen, toegevoegde schepen, aangewezen burgemeester, leden en voorzitter van bscd 

Currently only deployed on harvester-2 so the other harvesters will give errors
