### PR TITLE
Lmb 1055 | always use sparqlescape from mu

### DIFF
--- a/data-access/authorization.ts
+++ b/data-access/authorization.ts
@@ -1,7 +1,13 @@
+import { Request } from 'express';
+
 import { querySudo } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeUri, sparqlEscapeString } from 'mu';
-import { Request } from 'express';
+
 import { HttpError } from '../util/http-error';
+
+const VENDOR_KALLIOPE_URI = 'http://data.lblod.info/vendors/kalliope';
+const AUTOMATIC_SUBMISSION_GRAPH_URI =
+  'http://mu.semte.ch/graphs/automatic-submission';
 
 export const checkAuthorization = async (req: Request) => {
   const authorization = req.get('authorization');
@@ -22,9 +28,9 @@ export const checkAuthorization = async (req: Request) => {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     SELECT ?vendor WHERE {
-      GRAPH <http://mu.semte.ch/graphs/automatic-submission> {
+      GRAPH ${sparqlEscapeUri(AUTOMATIC_SUBMISSION_GRAPH_URI)} {
         ?vendor a foaf:Agent, ext:Vendor ;
-        muAccount:canActOnBehalfOf <http://data.lblod.info/vendors/kalliope> ;
+        muAccount:canActOnBehalfOf ${sparqlEscapeUri(VENDOR_KALLIOPE_URI)} ;
         muAccount:key ${sparqlEscapeString(password)} .
         VALUES ?vendor {
           ${sparqlEscapeUri(reconstructedUsername)}

--- a/data-access/beleidsdomein.ts
+++ b/data-access/beleidsdomein.ts
@@ -1,5 +1,6 @@
 import { sparqlEscapeString, sparqlEscapeUri, query } from 'mu';
 import { v4 as uuidv4 } from 'uuid';
+import { GRAPH, SCHEME } from '../util/constants';
 
 export const ensureBeleidsdomeinen = async (beleidsdomeinen: string[]) => {
   const existing = await getExistingBeleidsdomeinen(beleidsdomeinen);
@@ -15,7 +16,7 @@ const getExistingBeleidsdomeinen = async (beleidsdomeinen: string[]) => {
   SELECT ?uri ?label WHERE {
     ?uri a skos:Concept;
         skos:prefLabel ?label;
-        skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode>.
+        skos:inScheme ${sparqlEscapeUri(SCHEME.BELEIDSDOMEIN_CODE)}.
     VALUES ?label {
       ${beleidsdomeinen.map(sparqlEscapeString).join('\n')}
     }
@@ -44,8 +45,8 @@ const createMissingBeleidsdomeinen = async (beleidsdomeinen: string[]) => {
     return `${sparqlEscapeUri(concept.uri)} a skos:Concept;
       mu:uuid ${sparqlEscapeString(concept.uuid)};
       skos:prefLabel ${sparqlEscapeString(concept.name)};
-      skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode> ;
-      skos:topConceptOf <http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode> .`;
+      skos:inScheme ${sparqlEscapeUri(SCHEME.BELEIDSDOMEIN_CODE)} ;
+      skos:topConceptOf ${sparqlEscapeUri(SCHEME.BELEIDSDOMEIN_CODE)} .`;
   });
 
   const q = `
@@ -53,7 +54,7 @@ const createMissingBeleidsdomeinen = async (beleidsdomeinen: string[]) => {
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 
   INSERT DATA {
-    GRAPH <http://mu.semte.ch/graphs/application> {
+    GRAPH ${sparqlEscapeUri(GRAPH.APPLICATION)} {
       ${inserts.join('\n')}
     }
   }`;

--- a/data-access/file.ts
+++ b/data-access/file.ts
@@ -1,5 +1,5 @@
 import { updateSudo } from '@lblod/mu-auth-sudo';
-import { sparqlEscapeDateTime, sparqlEscapeUri } from 'mu';
+import { sparqlEscapeDateTime, sparqlEscapeUri, sparqlEscapeString } from 'mu';
 import { v4 as uuidv4 } from 'uuid';
 
 export const storeFile = async (file, orgGraph: string) => {
@@ -10,28 +10,47 @@ export const storeFile = async (file, orgGraph: string) => {
   const extension = file.originalname.split('.').pop();
   const uuid = uuidv4();
   const uuidDataObject = uuidv4();
-  const now = sparqlEscapeDateTime(new Date());
   const fileUri = `http://mu.semte.ch/services/file-service/files/${uuid}`;
+  const e = {
+    uuid: sparqlEscapeString(uuid),
+    uuidDataObject: sparqlEscapeString(uuidDataObject),
+    fileUri: sparqlEscapeUri(fileUri),
+    originalFileName: sparqlEscapeString(originalFileName),
+    format: sparqlEscapeString(format),
+    extension: sparqlEscapeString(extension),
+    generatedName: sparqlEscapeString(generatedName),
+    dateNow: sparqlEscapeDateTime(new Date()),
+    shareUri: sparqlEscapeUri(
+      `share://burgemeester-benoemingen/${generatedName}`,
+    ),
+  };
+
   await updateSudo(`
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+    PREFIX dbp: <http://dbpedia.org/ontology/>
+    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+    PREFIX: mu: <http://mu.semte.ch/vocabularies/core/>
+
     INSERT DATA {
       GRAPH ${sparqlEscapeUri(orgGraph)} {
-        <${fileUri}> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject> ;
-          <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName> "${originalFileName}" ;
-          <http://mu.semte.ch/vocabularies/core/uuid> "${uuid}" ;
-          <http://purl.org/dc/terms/format> "${format}" ;
-          <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize> "${size}"^^xsd:integer ;
-          <http://dbpedia.org/ontology/fileExtension> "${extension}" ;
-          <http://purl.org/dc/terms/created> ${now};
-          <http://purl.org/dc/terms/modified> ${now} .
-        <share://burgemeester-benoemingen/${generatedName}> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject> ;
-          <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> <${fileUri}> ;
-          <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName> "${generatedName}" ;
-          <http://mu.semte.ch/vocabularies/core/uuid> "${uuidDataObject}" ;
-          <http://purl.org/dc/terms/format> "${format}" ;
-          <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileSize> "${size}"^^xsd:integer ;
-          <http://dbpedia.org/ontology/fileExtension> "${extension}" ;
-          <http://purl.org/dc/terms/created> ${now} ;
-          <http://purl.org/dc/terms/modified> ${now} .
+        ${e.fileUri} a nfo:FileDataObject> ;
+          nfo:fileName ${e.originalFileName} ;
+          mu:uuid ${e.uuid} ;
+          dcterms:format ${e.format} ;
+          nfo:fileSize "${size}"^^xsd:integer ;
+          dbp:fileExtension ${e.extension} ;
+          dcterms:created ${e.dateNow};
+          dcterms:modified ${e.dateNow} .
+        ${e.shareUri} a nfo:FileDataObject ;
+          nie:dataSource ${e.fileUri} ;
+          nfo:fileName ${e.generatedName} ;
+          mu:uuid ${e.uuidDataObject} ;
+          dcterms:format ${e.format} ;
+          nfo:fileSize "${size}"^^xsd:integer ;
+          dbp:fileExtension ${e.extension} ;
+          dcterms:created ${e.dateNow} ;
+          dcterms:modified ${e.dateNow} .
       }
     }`);
   return fileUri;

--- a/data-access/form-queries.ts
+++ b/data-access/form-queries.ts
@@ -2,6 +2,9 @@ import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeUri, sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
 import { v4 as uuid } from 'uuid';
 import { findFirstSparqlResult } from '../util/sparql-result';
+import { GRAPH } from '../util/constants';
+
+const FORM_HISTORY_TYPE_URI = 'http://mu.semte.ch/vocabularies/ext/FormHistory';
 
 export const fetchUserIdFromSession = async (sessionUri: string) => {
   const queryResult = await querySudo(`
@@ -24,7 +27,9 @@ export const saveHistoryItem = async (
   creatorUri: string,
   description?: string,
 ) => {
-  const historyGraph = `<http://mu.semte.ch/graphs/formHistory/${uuid()}>`;
+  const historyGraph = sparqlEscapeUri(
+    `<http://mu.semte.ch/graphs/formHistory/${uuid()}>`,
+  );
 
   let descriptionInsert = '';
   if (description && description.trim().length > 0) {
@@ -36,8 +41,8 @@ export const saveHistoryItem = async (
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
     INSERT {
-      GRAPH <http://mu.semte.ch/graphs/formHistory> {
-        ${historyGraph} a <http://mu.semte.ch/vocabularies/ext/FormHistory> ;
+      GRAPH ${sparqlEscapeUri(GRAPH.FORM_HISTORY)} {
+        ${historyGraph} a ${sparqlEscapeUri(FORM_HISTORY_TYPE_URI)} ;
           dct:isVersionOf ${sparqlEscapeUri(instanceUri)} ;
           dct:issued ${sparqlEscapeDateTime(new Date())} ;
           dct:creator ${sparqlEscapeUri(creatorUri)} ${descriptionInsert}.

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -119,7 +119,7 @@ async function removeFractieWhenNoLidmaatschap(
         lmb:heeftBestuursperiode ?bestuursperiode.
       ?fractie a mandaat:Fractie;
         org:memberOf ?bestuursorgaan;
-        ext:isFractietype <http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk>.
+        ext:isFractietype ${sparqlEscapeUri(FRACTIE_TYPE.ONAFHANKELIJK)} .
 
       FILTER NOT EXISTS {
         ?lidmaatschap a org:Membership;

--- a/data-access/mandaat.ts
+++ b/data-access/mandaat.ts
@@ -1,7 +1,19 @@
-import { query, sparqlEscapeString, sparqlEscapeDateTime } from 'mu';
+import {
+  query,
+  sparqlEscapeString,
+  sparqlEscapeDateTime,
+  sparqlEscapeUri,
+} from 'mu';
+
+import { MANDATARIS_STATUS } from '../util/constants';
 
 export const getNbActiveMandatarissen = async (mandaatId: string) => {
   const now = sparqlEscapeDateTime(new Date());
+  const escapedStatus = [
+    sparqlEscapeUri(MANDATARIS_STATUS.EFFECTIEF),
+    sparqlEscapeUri(MANDATARIS_STATUS.VERHINDERD),
+    sparqlEscapeUri(MANDATARIS_STATUS.TITELVOEREND),
+  ];
   const q = `
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
   PREFIX org: <http://www.w3.org/ns/org#>
@@ -30,7 +42,7 @@ export const getNbActiveMandatarissen = async (mandaatId: string) => {
     BIND(IF(?actualOrgaanEinde <= ${now}, ?actualOrgaanEinde - "P1D"^^xsd:duration, ${now}) AS ?testEinde).
     FILTER(!BOUND(?mandatarisEinde) || ?mandatarisEinde >= ?testEinde).
     # Filter mandatarissen that are either effectief, verhinderd or titelvoerend (or have no status)
-    FILTER(!BOUND(?status) || ?status IN (<http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75>, <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe>, <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3>)).
+    FILTER(!BOUND(?status) || ?status IN ( ${escapedStatus.join(', ')} )).
 
     ?g ext:ownedBy ?owningEenheid.
   }

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { CSVRow, CsvUploadState, MandateHit, TermProperty } from '../types';
 
 import {
+  FRACTIE_TYPE,
   MANDATARIS_STATUS,
   PUBLICATION_STATUS,
   STATUS_CODE,
@@ -40,6 +41,7 @@ export const mandataris = {
 };
 
 async function isOnafhankelijk(mandatarisId: string): Promise<boolean> {
+  const fractieTypeOnafhankelijk = sparqlEscapeUri(FRACTIE_TYPE.ONAFHANKELIJK);
   const getQuery = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -51,7 +53,7 @@ async function isOnafhankelijk(mandatarisId: string): Promise<boolean> {
         mu:uuid ${sparqlEscapeString(mandatarisId)} ;
         org:hasMembership ?lidmaatschap .
         ?lidmaatschap org:organisation ?fractie .
-        ?fractie ext:isFractietype <http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk> .
+        ?fractie ext:isFractietype ${fractieTypeOnafhankelijk} .
     }
   `;
 
@@ -110,6 +112,7 @@ export async function findOnafhankelijkeFractieForPerson(
   personUri: string,
   mandateUris: string[],
 ) {
+  const fractieTypeOnafhankelijk = sparqlEscapeUri(FRACTIE_TYPE.ONAFHANKELIJK);
   const getQuery = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -117,7 +120,7 @@ export async function findOnafhankelijkeFractieForPerson(
 
     SELECT DISTINCT ?fractie WHERE {
       ?fractie a mandaat:Fractie .
-      ?fractie ext:isFractietype <http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk> .
+      ?fractie ext:isFractietype ${fractieTypeOnafhankelijk} .
       ?fractie org:memberOf ?bestuursorgaan.
 
       ?bestuursorgaan org:hasPost ?mandate.
@@ -152,7 +155,7 @@ export async function createOnafhankelijkeFractie(mandateUris: string[]) {
     INSERT {
       GRAPH ?g {
         ${sparqlEscapeUri(uri)} a mandaat:Fractie ;
-          ext:isFractietype <http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk> ;
+          ext:isFractietype ${sparqlEscapeUri(FRACTIE_TYPE.ONAFHANKELIJK)} ;
           regorg:legalName "Onafhankelijk" ;
           mu:uuid ${sparqlEscapeString(uuid)} ;
           org:linkedTo ?bestuurseenheid ;
@@ -343,7 +346,7 @@ export const createMandatarisInstance = async (
         mandaat:einde ${sparqlEscapeDateTime(mandatarisEnd)} ;
         org:holds ${sparqlEscapeUri(mandate.mandateUri)} ;
         # effectief
-        mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> ;
+        mandaat:status ${sparqlEscapeUri(MANDATARIS_STATUS.EFFECTIEF)} ;
         # bekrachtigd
         lmb:hasPublicationStatus mps:9d8fd14d-95d0-4f5e-b3a5-a56a126227b6 .
 

--- a/data-access/mandatees-decisions.ts
+++ b/data-access/mandatees-decisions.ts
@@ -1,6 +1,8 @@
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeUri } from 'mu';
+
 import { MandatarisBesluitLookup, Term, Triple } from '../types';
+
 import {
   createNotification,
   getMandatarisNotificationGraph,
@@ -10,6 +12,7 @@ import {
   getBooleanSparqlResult,
   getSparqlResults,
 } from '../util/sparql-result';
+import { GRAPH } from '../util/constants';
 
 export const BESLUIT_STAGING_GRAPH =
   process.env.BESLUIT_STAGING_GRAPH ||
@@ -160,9 +163,11 @@ export async function checkIfMandatarisExists(mandatarisUri) {
   const safeMandatarisUri = sparqlEscapeUri(mandatarisUri);
   const query = `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+
     ASK {
       GRAPH ?g {
-        ${safeMandatarisUri} a <http://data.vlaanderen.be/ns/mandaat#Mandataris> .
+        ${safeMandatarisUri} a mandaat:Mandataris .
       }
       ?g ext:ownedBy ?bestuurseenheid.
     }
@@ -376,7 +381,7 @@ export async function copyPersonToGraph(personUri: string, graph: string) {
       }
     }
     ?g ext:ownedBy ?bestuurseenheid.
-    FILTER (?g = <http://mu.semte.ch/graphs/public> || BOUND(?bestuurseenheid))
+    FILTER (?g = ${sparqlEscapeUri(GRAPH.PUBLIC)} || BOUND(?bestuurseenheid))
   }`;
   await updateSudo(query);
 }
@@ -400,7 +405,7 @@ export async function copySimpleInstanceToGraph(
       ${safeInstanceUri} ?p ?o .
     }
     ?g ext:ownedBy ?bestuurseenheid.
-    FILTER (?g = <http://mu.semte.ch/graphs/public> || BOUND(?bestuurseenheid))
+    FILTER (?g = ${sparqlEscapeUri(GRAPH.PUBLIC)} || BOUND(?bestuurseenheid))
   }`;
   await updateSudo(query);
 }

--- a/data-access/persoon.ts
+++ b/data-access/persoon.ts
@@ -7,10 +7,12 @@ import {
   update,
 } from 'mu';
 import { v4 as uuidv4 } from 'uuid';
+
 import {
   findFirstSparqlResult,
   getBooleanSparqlResult,
 } from '../util/sparql-result';
+import { FRACTIE_TYPE, GRAPH } from '../util/constants';
 
 // note since we use the regular query, not sudo queries, be sure to log in when using this endpoint. E.g. use the vendor login
 
@@ -70,7 +72,7 @@ export const createPerson = async (
   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
   INSERT DATA {
-    GRAPH <http://mu.semte.ch/graphs/application> {
+    GRAPH ${sparqlEscapeUri(GRAPH.APPLICATION)} {
       ${sparqlEscapeUri(uri)} a person:Person;
           mu:uuid ${sparqlEscapeString(uuid)};
           persoon:gebruikteVoornaam ${sparqlEscapeString(fName)};
@@ -157,7 +159,7 @@ export async function isOnafhankelijkInPeriod(
           extlmb:currentFracties ?fractie .
         ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode .
         ?fractie org:memberOf ?bestuursorgaan ;
-          ext:isFractietype <http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk> .
+          ext:isFractietype ${sparqlEscapeUri(FRACTIE_TYPE.ONAFHANKELIJK)} .
       }
       ?bestuursperiode mu:uuid ${sparqlEscapeString(bestuursperiodeId)} .
     }

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -1,5 +1,17 @@
 export enum MANDATARIS_STATUS {
   EFFECTIEF = 'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75',
+  VERHINDERD = 'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe',
+  TITELVOEREND = 'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3',
+}
+
+export enum CLASSIFICATIE_CODE {
+  DISTRICT = 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003',
+  BURGEMEESTER = 'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284',
+}
+
+export enum FUNCTIE_CODE {
+  BURGEMEESTER = 'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013',
+  AANGEWEZEN_BURGEMEESTER = 'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a',
 }
 
 export enum PUBLICATION_STATUS {
@@ -13,6 +25,17 @@ export enum FRACTIE_TYPE {
   ONAFHANKELIJK = 'http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk',
 }
 
+export enum GRAPH {
+  FORM_HISTORY = 'http://mu.semte.ch/graphs/formHistory',
+  LINKED_INSTANCES = 'http://mu.semte.ch/graphs/linkedInstances',
+  PUBLIC = 'http://mu.semte.ch/graphs/public',
+  APPLICATION = 'http://mu.semte.ch/graphs/application',
+}
+
+export enum SCHEME {
+  BELEIDSDOMEIN_CODE = 'http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode',
+}
+
 export enum STATUS_CODE {
   OK = 200,
   CREATED = 201,
@@ -24,6 +47,7 @@ export enum BENOEMING_STATUS {
   AFGEWEZEN = 'afgewezen',
 }
 
+// TODO: Transform these to enums
 export const GEMEENTERAADSLID_FUNCTIE_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011';
 export const LID_OCMW_FUNCTIE_CODE =

--- a/util/mu/prefixes.ts
+++ b/util/mu/prefixes.ts
@@ -1,0 +1,42 @@
+import { sparqlEscapeUri } from 'mu';
+
+const mapping = {
+  mu: 'http://mu.semte.ch/vocabularies/core/',
+  besluit: 'http://data.vlaanderen.be/ns/besluit#',
+  mandaat: 'http://data.vlaanderen.be/ns/mandaat#',
+  org: 'http://www.w3.org/ns/org#',
+  lmb: 'http://lblod.data.gift/vocabularies/lmb/',
+  ext: 'http://mu.semte.ch/vocabularies/ext/',
+  person: 'http://www.w3.org/ns/person#',
+  extlmb: 'http://mu.semte.ch/vocabularies/ext/lmb/',
+  xsd: 'http://www.w3.org/2001/XMLSchema#',
+  astreams: 'http://www.w3.org/ns/activitystreams#',
+  skos: 'http://www.w3.org/2004/02/skos/core#',
+  persoon: 'http://data.vlaanderen.be/ns/persoon#',
+  adms: 'http://www.w3.org/ns/adms#',
+  regorg: 'https://www.w3.org/ns/regorg#',
+  muAccount: 'http://mu.semte.ch/vocabularies/account/',
+  foaf: 'http://xmlns.com/foaf/0.1/',
+  dcterms: 'http://purl.org/dc/terms/',
+  dct: 'http://purl.org/dc/terms/',
+  nfo: 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
+  dbp: 'http://dbpedia.org/ontology/',
+  nie: 'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#',
+  session: 'http://mu.semte.ch/vocabularies/session/',
+  generiek: 'http://data.vlaanderen.be/ns/generiek#',
+  rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+  owl: 'http://www.w3.org/2002/07/owl#',
+  schema: 'http://schema.org/',
+};
+
+export function getPrefixesForQuery(sparqlQuery: string) {
+  const prefixes: string[] = [];
+
+  for (const key in mapping) {
+    if (sparqlQuery.includes(`${key}:`)) {
+      prefixes.push(`PREFIX ${key}: ${sparqlEscapeUri(mapping[key])}`);
+    }
+  }
+
+  return prefixes;
+}

--- a/util/mu/query-sparql.ts
+++ b/util/mu/query-sparql.ts
@@ -1,0 +1,38 @@
+import { query as mu_query, update as mu_update } from 'mu';
+import {
+  querySudo as mu_querySudo,
+  updateSudo as mu_updateSudo,
+} from '@lblod/mu-auth-sudo';
+
+import { getPrefixesForQuery } from './prefixes';
+
+export async function query(sparqlQuery: string) {
+  return await mu_query(getQueryWithPrefixes(sparqlQuery));
+}
+
+export async function update(sparqlQuery: string) {
+  return await mu_update(getQueryWithPrefixes(sparqlQuery));
+}
+export async function querySudo(sparqlQuery: string) {
+  return await mu_querySudo(getQueryWithPrefixes(sparqlQuery));
+}
+
+export async function updateSudo(sparqlQuery: string) {
+  return await mu_updateSudo(getQueryWithPrefixes(sparqlQuery));
+}
+
+function getQueryWithPrefixes(sparqlQuery) {
+  const startTime = performance.now();
+  const prefixes = getPrefixesForQuery(sparqlQuery);
+  console.log(
+    `\n\n\tPERFORMANCE: getting the prefixes took: ${
+      performance.now() - startTime
+    } ms \n\n`,
+  );
+  return `
+    # generated prefixes
+    ${prefixes.join('\n')}
+    # end generated prefixes
+    ${sparqlQuery}
+  `;
+}


### PR DESCRIPTION
## Description

We want every value in the query to be escaped to prevent sparql injection.

Tested out on inserting the prefixes in the query instead of defining them.

## How to test

- all values are escaped
- have a look if we want to remove the prefixes as done in `/data-access/mandataris`

## Links to other PR's

- /
