### PR TITLE
LMB-1288 make end dates of mandatarissen end of day end dates

### DIFF
--- a/controllers/linked-mandataris.ts
+++ b/controllers/linked-mandataris.ts
@@ -36,6 +36,7 @@ import {
   VOORZITTER_RMW_CODE,
   VOORZITTER_VB_FUNCTIE_CODE,
 } from '../util/constants';
+import moment from 'moment';
 
 export const checkLinkedMandataris = async (req) => {
   const mandatarisId = req.params.id;
@@ -274,7 +275,7 @@ export const changeStateLinkedMandataris = async (req) => {
   await linkInstances(newMandatarisId, newLinkedMandataris.id);
 
   // End original linked mandatee
-  const endDate = new Date();
+  const endDate = moment().add(1, 'days').startOf('day').toDate();
   endExistingMandataris(destinationGraph, linkedMandataris.uri, endDate);
 };
 

--- a/controllers/linked-mandataris.ts
+++ b/controllers/linked-mandataris.ts
@@ -36,7 +36,7 @@ import {
   VOORZITTER_RMW_CODE,
   VOORZITTER_VB_FUNCTIE_CODE,
 } from '../util/constants';
-import moment from 'moment';
+import { endOfDay } from '../util/date-manipulation';
 
 export const checkLinkedMandataris = async (req) => {
   const mandatarisId = req.params.id;
@@ -275,8 +275,7 @@ export const changeStateLinkedMandataris = async (req) => {
   await linkInstances(newMandatarisId, newLinkedMandataris.id);
 
   // End original linked mandatee
-  const endDate = moment().add(1, 'days').startOf('day').toDate();
-  endExistingMandataris(destinationGraph, linkedMandataris.uri, endDate);
+  endExistingMandataris(destinationGraph, linkedMandataris.uri, endOfDay());
 };
 
 const preliminaryChecksLinkedMandataris = async (req) => {

--- a/controllers/mandataris.ts
+++ b/controllers/mandataris.ts
@@ -14,7 +14,7 @@ import { createRangorde } from '../util/rangorde';
 import { v4 as uuidv4 } from 'uuid';
 import { areIdsValid, isValidId, RDF_TYPE } from '../util/valid-id';
 
-import moment from 'moment';
+import { endOfDay } from '../util/date-manipulation';
 
 export const mandatarisUsecase = {
   getMandatarisFracties,
@@ -233,8 +233,7 @@ async function setEndDateOfActiveMandatarissen(
   const activeMandatarisUris =
     await mandataris.getActiveMandatarissenForPerson(id);
 
-  const tomorrowStartOfDay = moment().add(1, 'days').startOf('day').toDate();
-  await mandataris.bulkUpdateEndDate(activeMandatarisUris, tomorrowStartOfDay);
+  await mandataris.bulkUpdateEndDate(activeMandatarisUris, endOfDay());
   await saveBulkHistoryItem(
     activeMandatarisUris,
     userId,

--- a/controllers/mandataris.ts
+++ b/controllers/mandataris.ts
@@ -14,6 +14,8 @@ import { createRangorde } from '../util/rangorde';
 import { v4 as uuidv4 } from 'uuid';
 import { areIdsValid, isValidId, RDF_TYPE } from '../util/valid-id';
 
+import moment from 'moment';
+
 export const mandatarisUsecase = {
   getMandatarisFracties,
   updateCurrentFractie,
@@ -231,7 +233,8 @@ async function setEndDateOfActiveMandatarissen(
   const activeMandatarisUris =
     await mandataris.getActiveMandatarissenForPerson(id);
 
-  await mandataris.bulkUpdateEndDate(activeMandatarisUris, new Date());
+  const tomorrowStartOfDay = moment().add(1, 'days').startOf('day').toDate();
+  await mandataris.bulkUpdateEndDate(activeMandatarisUris, tomorrowStartOfDay);
   await saveBulkHistoryItem(
     activeMandatarisUris,
     userId,

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -11,6 +11,7 @@ import {
   copyFromPreviousMandataris,
   endExistingMandataris,
 } from './mandataris';
+import moment from 'moment';
 
 export async function isBestuurseenheidDistrict(
   bestuurseenheidUri: string,
@@ -132,7 +133,13 @@ export const markCurrentBurgemeesterAsRejected = async (
     );
   }
 
-  await endExistingMandataris(orgGraph, existingMandatarisUri, date, benoeming);
+  const endDate = moment(date).add(1, 'days').startOf('day').toDate();
+  await endExistingMandataris(
+    orgGraph,
+    existingMandatarisUri,
+    endDate,
+    benoeming,
+  );
 
   // TODO: check use case if mandataris is waarnemend -> should something happen to the verhindering?
 
@@ -202,10 +209,11 @@ export const benoemBurgemeester = async (
       burgemeesterMandaatUri,
     );
 
+    const endDate = moment(date).add(1, 'days').startOf('day').toDate();
     await endExistingMandataris(
       orgGraph,
       existingMandataris,
-      date,
+      endDate,
       benoemingUri,
     );
   } else {

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -11,7 +11,7 @@ import {
   copyFromPreviousMandataris,
   endExistingMandataris,
 } from './mandataris';
-import moment from 'moment';
+import { endOfDay } from '../util/date-manipulation';
 
 export async function isBestuurseenheidDistrict(
   bestuurseenheidUri: string,
@@ -133,11 +133,10 @@ export const markCurrentBurgemeesterAsRejected = async (
     );
   }
 
-  const endDate = moment(date).add(1, 'days').startOf('day').toDate();
   await endExistingMandataris(
     orgGraph,
     existingMandatarisUri,
-    endDate,
+    endOfDay(date),
     benoeming,
   );
 
@@ -209,11 +208,10 @@ export const benoemBurgemeester = async (
       burgemeesterMandaatUri,
     );
 
-    const endDate = moment(date).add(1, 'days').startOf('day').toDate();
     await endExistingMandataris(
       orgGraph,
       existingMandataris,
-      endDate,
+      endOfDay(date),
       benoemingUri,
     );
   } else {

--- a/data-access/mandataris-download.ts
+++ b/data-access/mandataris-download.ts
@@ -46,7 +46,7 @@ async function getUrisForFilters(filters) {
       FILTER (
         ?safeEinde <= ?safeEindeBestuursorgaan &&
         ?safeEinde >= ?startBestuursorgaan &&
-        ?safeEinde >= ${escapedTodaysDate}
+        ?safeEinde > ${escapedTodaysDate}
       )
     `;
   }

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -894,7 +894,7 @@ async function getActiveMandatarissenForPerson(persoonId: string) {
       }
       FILTER (
           ${escaped.dateNow} >= xsd:dateTime(?startDate) &&
-          ${escaped.dateNow} <= ?safeEnd
+          ${escaped.dateNow} < ?safeEnd
       )
       BIND(IF(BOUND(?endDate), ?endDate,  ${escaped.dateNow}) as ?safeEnd )
     }

--- a/util/date-manipulation.ts
+++ b/util/date-manipulation.ts
@@ -1,0 +1,9 @@
+import moment from 'moment';
+
+export function endOfDay(date?: Date) {
+  if (date) {
+    return moment(date).add(1, 'days').startOf('day').toDate();
+  } else {
+    return moment().add(1, 'days').startOf('day').toDate();
+  }
+}


### PR DESCRIPTION
## Description

Add a day to some queries when setting the end date for mandatarissen.

## How to test

To test you need to trigger the flows that trigger the specific endpoints that update mandataris end dates, such as burgemeesterbenoeming, end active mandatees of a person ...

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/465
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/358
