### PR TITLE
Ben/lmb 1319 improve burgemeester bekrachtiging

### DIFF
--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -159,7 +159,12 @@ const markCurrentBurgemeesterAsRejected = async (
     );
   }
 
-  await endExistingMandataris(orgGraph, existingMandatarisUri, date, benoemingUri);
+  await endExistingMandataris(
+    orgGraph,
+    existingMandatarisUri,
+    date,
+    benoemingUri,
+  );
 
   // TODO: check use case if mandataris is waarnemend -> should something happen to the verhindering?
 

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -5,6 +5,7 @@ import {
   addBenoemingTriple,
   createBurgemeesterBenoeming,
   createBurgemeesterFromScratch,
+  createNotificationAangesteldeBurgemeester,
   createNotificationAfgewezenBurgemeester,
   createNotificationMultipleBurgemeesters,
   findBurgemeesterMandates,
@@ -298,6 +299,13 @@ const transferAangewezenBurgemeesterToBurgemeester = async (
       mandataris,
       benoemingUri,
       BENOEMING_STATUS.BENOEMD,
+    );
+  }
+
+  if (newBurgemeesterMandatarissen.length == 1) {
+    createNotificationAangesteldeBurgemeester(
+      orgGraph,
+      newBurgemeesterMandatarissen.at(0),
     );
   }
 };

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -7,6 +7,7 @@ import {
   createBurgemeesterFromScratch,
   createNotificationAangesteldeBurgemeester,
   createNotificationAfgewezenBurgemeester,
+  createNotificationMultipleAangesteldeBurgemeesters,
   createNotificationOtherPersonWithBurgemeesterMandaat,
   findBurgemeesterMandates,
   getPersoonMandaatMandataris,
@@ -309,6 +310,11 @@ const transferAangewezenBurgemeesterToBurgemeester = async (
     createNotificationAangesteldeBurgemeester(
       orgGraph,
       newBurgemeesterMandatarissen.at(0),
+    );
+  } else if (newBurgemeesterMandatarissen.length >= 1) {
+    createNotificationMultipleAangesteldeBurgemeesters(
+      orgGraph,
+      newBurgemeesterMandatarissen,
     );
   }
 };

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -146,6 +146,7 @@ const handleBurgemeester = async (
       date,
       PUBLICATION_STATUS.BEKRACHTIGD,
     );
+    return burgemeesterMandatarisExists;
   }
 
   // Check if burgemeester exists for another person

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -7,7 +7,7 @@ import {
   createBurgemeesterFromScratch,
   createNotificationAangesteldeBurgemeester,
   createNotificationAfgewezenBurgemeester,
-  createNotificationMultipleBurgemeesters,
+  createNotificationOtherPersonWithBurgemeesterMandaat,
   findBurgemeesterMandates,
   getPersoonMandaatMandataris,
   getPersoonMandaatMandatarissen,
@@ -173,7 +173,10 @@ const handleBurgemeester = async (
 
   // If so create notification
   if (otherBurgemeesterFound) {
-    createNotificationMultipleBurgemeesters(orgGraph, otherBurgemeesterFound);
+    createNotificationOtherPersonWithBurgemeesterMandaat(
+      orgGraph,
+      otherBurgemeesterFound,
+    );
   }
 
   if (existingMandataris) {

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -10,12 +10,10 @@ import {
   createNotificationMultipleAangesteldeBurgemeesters,
   createNotificationOtherPersonWithBurgemeesterMandaat,
   findBurgemeesterMandates,
-  getPersoonMandaatMandataris,
   getPersoonMandaatMandatarissen,
   isBestuurseenheidDistrict,
   otherPersonHasMandate,
-  setPublicationSatusWithDate,
-  setPublicationStatusMandatarissenWithDate,
+  setPublicationStatusWithDate,
 } from '../data-access/burgemeester';
 import { BENOEMING_STATUS, PUBLICATION_STATUS } from '../util/constants';
 import { checkAuthorization } from '../data-access/authorization';
@@ -26,7 +24,6 @@ import {
 } from '../data-access/mandataris';
 import { personExistsInGraph } from '../data-access/persoon';
 import {
-  linkedMandateAlreadyExists,
   linkedMandateExists,
   linkInstancesOnUri,
   unlinkInstanceOnUri,
@@ -154,7 +151,7 @@ const handleBurgemeester = async (
   // If it exists, just bekrachtig it
   if (burgemeesterMandatarissenExist) {
     for (const burgemeesterMandataris in burgemeesterMandatarissenExist) {
-      setPublicationStatusMandatarissenWithDate(
+      setPublicationStatusWithDate(
         orgGraph,
         burgemeesterMandataris,
         date,

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -5,6 +5,7 @@ import {
   addBenoemingTriple,
   createBurgemeesterBenoeming,
   createBurgemeesterFromScratch,
+  createNotificationAfgewezenBurgemeester,
   createNotificationMultipleBurgemeesters,
   findBurgemeesterMandates,
   getPersoonMandaatMandataris,
@@ -330,6 +331,8 @@ const markCurrentBurgemeesterAsRejected = async (
     benoemingUri,
     BENOEMING_STATUS.AFGEWEZEN,
   );
+
+  createNotificationAfgewezenBurgemeester(orgGraph, existingMandatarisUri);
 };
 
 const onBurgemeesterBenoemingSafe = async (req: Request) => {

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -5,6 +5,7 @@ import {
   addBenoemingTriple,
   createBurgemeesterBenoeming,
   createBurgemeesterFromScratch,
+  createNotificationMultipleBurgemeesters,
   findBurgemeesterMandates,
   getPersoonMandaatMandataris,
   isBestuurseenheidDistrict,
@@ -158,6 +159,9 @@ const handleBurgemeester = async (
   );
 
   // If so create notification
+  if (otherBurgemeesterFound) {
+    createNotificationMultipleBurgemeesters(orgGraph);
+  }
 
   if (existingMandataris) {
     // we can copy over the existing values for the new burgemeester from the previous mandataris

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -8,6 +8,7 @@ import {
   createNotificationMultipleBurgemeesters,
   findBurgemeesterMandates,
   getPersoonMandaatMandataris,
+  getPersoonMandaatMandatarissen,
   isBestuurseenheidDistrict,
   otherPersonHasMandate,
   setPublicationSatusWithDate,
@@ -139,7 +140,7 @@ const handleBurgemeester = async (
   existingMandataris: string | undefined | null,
 ) => {
   // Check if burgemeester already exists for the person
-  const burgemeesterMandatarisExists = await getPersoonMandaatMandataris(
+  const burgemeesterMandatarisExists = await getPersoonMandaatMandatarissen(
     orgGraph,
     burgemeesterPersoonUri,
     burgemeesterMandaatUri,

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -159,7 +159,7 @@ const markCurrentBurgemeesterAsRejected = async (
     );
   }
 
-  await endExistingMandataris(orgGraph, existingMandatarisUri, date, benoeming);
+  await endExistingMandataris(orgGraph, existingMandatarisUri, date, benoemingUri);
 
   // TODO: check use case if mandataris is waarnemend -> should something happen to the verhindering?
 

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -9,8 +9,9 @@ import {
   getPersoonMandaatMandataris,
   isBestuurseenheidDistrict,
   otherPersonHasMandate,
+  setPublicationSatusWithDate,
 } from '../data-access/burgemeester';
-import { BENOEMING_STATUS } from '../util/constants';
+import { BENOEMING_STATUS, PUBLICATION_STATUS } from '../util/constants';
 import { checkAuthorization } from '../data-access/authorization';
 import {
   copyFromPreviousMandataris,
@@ -130,7 +131,7 @@ const handleBurgemeester = async (
   existingMandataris: string | undefined | null,
 ) => {
   // Check if burgemeester already exists for the person
-  const burgemeesterMandatarisExists = getPersoonMandaatMandataris(
+  const burgemeesterMandatarisExists = await getPersoonMandaatMandataris(
     orgGraph,
     burgemeesterPersoonUri,
     burgemeesterMandaatUri,
@@ -138,6 +139,14 @@ const handleBurgemeester = async (
   );
 
   // If it exists, just bekrachtig it
+  if (burgemeesterMandatarisExists) {
+    setPublicationSatusWithDate(
+      orgGraph,
+      burgemeesterMandatarisExists,
+      date,
+      PUBLICATION_STATUS.BEKRACHTIGD,
+    );
+  }
 
   // Check if burgemeester exists for another person
   const otherBurgemeesterFound = otherPersonHasMandate(

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -20,6 +20,11 @@ import {
   findExistingMandatarisOfPerson,
 } from '../data-access/mandataris';
 import { personExistsInGraph } from '../data-access/persoon';
+import {
+  linkedMandateAlreadyExists,
+  linkedMandateExists,
+} from '../data-access/linked-mandataris';
+import { getLinkedMandates } from './linked-mandataris';
 
 const parseBody = (body) => {
   if (body == null) {
@@ -196,11 +201,22 @@ const handleLinkedMandatarisBurgemeester = async (
   }
 
   // Check if aangewezen burgemeester has linked mandataris
+  const linkedMandatarisABExists = linkedMandateExists(
+    aangewezenBurgemeesterUri,
+    orgGraph,
+    getLinkedMandates,
+  );
+  const linkedMandatarisBExists = linkedMandateExists(
+    newBurgemeesterUri,
+    orgGraph,
+    getLinkedMandates,
+  );
+
   // If it does and the burgemeester has none
   // End linked mandataris
   // Copy linked mandataris
-
   // Set linked on burgemeester
+
   // If it does and the burgemeester has one as well
   // Check if different
   // If not -> repeat steps above

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -191,10 +191,15 @@ const handleLinkedMandatarisBurgemeester = async (
   benoemingUri: string,
 ) => {
   // If no aangewezen burgemeester -> early return
+  if (!aangewezenBurgemeesterUri) {
+    return;
+  }
+
   // Check if aangewezen burgemeester has linked mandataris
   // If it does and the burgemeester has none
   // End linked mandataris
   // Copy linked mandataris
+
   // Set linked on burgemeester
   // If it does and the burgemeester has one as well
   // Check if different

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -127,6 +127,14 @@ const handleBurgemeester = async (
   benoemingUri: string,
   existingMandataris: string | undefined | null,
 ) => {
+  // Check if burgemeester already exists for the person
+
+  // If it exists, just bekrachtig it
+
+  // Check if burgemeester exists for another person
+
+  // If so create notification
+
   if (existingMandataris) {
     // we can copy over the existing values for the new burgemeester from the previous mandataris
     return await copyFromPreviousMandataris(
@@ -149,12 +157,21 @@ const handleBurgemeester = async (
 
 const handleLinkedMandatarisBurgemeester = async (
   orgGraph: string,
+  aangewezenBurgemeesterUri: string | undefined | null,
   newBurgemeesterUri: string,
   date: Date,
   benoemingUri: string,
-  existingMandataris: string | undefined | null,
 ) => {
-  // TODO
+  // If no aangewezen burgemeester -> early return
+  // Check if aangewezen burgemeester has linked mandataris
+  // If it does and the burgemeester has none
+  // End linked mandataris
+  // Copy linked mandataris
+  // Set linked on burgemeester
+  // If it does and the burgemeester has one as well
+  // Check if different
+  // If not -> repeat steps above
+  // If different -> just end the one from the aangewezen burgemeester
 };
 
 const transferAangewezenBurgemeesterToBurgemeester = async (
@@ -183,10 +200,10 @@ const transferAangewezenBurgemeesterToBurgemeester = async (
 
   handleLinkedMandatarisBurgemeester(
     orgGraph,
+    existingMandataris,
     newMandatarisUri,
     date,
     benoemingUri,
-    existingMandataris,
   );
 
   addBenoemingTriple(

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -6,6 +6,7 @@ import {
   createBurgemeesterBenoeming,
   createBurgemeesterFromScratch,
   findBurgemeesterMandates,
+  getPersoonMandaatMandataris,
   isBestuurseenheidDistrict,
 } from '../data-access/burgemeester';
 import { BENOEMING_STATUS } from '../util/constants';
@@ -128,6 +129,12 @@ const handleBurgemeester = async (
   existingMandataris: string | undefined | null,
 ) => {
   // Check if burgemeester already exists for the person
+  const burgemeesterMandatarisExists = getPersoonMandaatMandataris(
+    orgGraph,
+    burgemeesterPersoonUri,
+    burgemeesterMandaatUri,
+    date,
+  );
 
   // If it exists, just bekrachtig it
 

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -8,6 +8,7 @@ import {
   findBurgemeesterMandates,
   getPersoonMandaatMandataris,
   isBestuurseenheidDistrict,
+  otherPersonHasMandate,
 } from '../data-access/burgemeester';
 import { BENOEMING_STATUS } from '../util/constants';
 import { checkAuthorization } from '../data-access/authorization';
@@ -139,6 +140,12 @@ const handleBurgemeester = async (
   // If it exists, just bekrachtig it
 
   // Check if burgemeester exists for another person
+  const otherBurgemeesterFound = otherPersonHasMandate(
+    orgGraph,
+    burgemeesterPersoonUri,
+    burgemeesterMandaatUri,
+    date,
+  );
 
   // If so create notification
 

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -103,40 +103,92 @@ const validateAndParseRequest = async (req: Request) => {
   };
 };
 
-const transferAangewezenBurgemeesterToBurgemeester = async (
+const handleAangewezenBurgemeester = async (
   orgGraph: string,
-  burgemeesterUri: string,
-  burgemeesterMandaatUri: string,
+  existingMandataris: string | undefined | null,
   date: Date,
   benoemingUri: string,
-  existingMandataris: string | undefined | null,
 ) => {
-  let newMandatarisUri;
   if (existingMandataris) {
-    // we can copy over the existing values for the new burgemeester from the previous mandataris
-    newMandatarisUri = await copyFromPreviousMandataris(
-      orgGraph,
-      existingMandataris,
-      date,
-      burgemeesterMandaatUri,
-    );
-
     await endExistingMandataris(
       orgGraph,
       existingMandataris,
       date,
       benoemingUri,
     );
+  }
+};
+
+const handleBurgemeester = async (
+  orgGraph: string,
+  burgemeesterPersoonUri: string,
+  burgemeesterMandaatUri: string,
+  date: Date,
+  benoemingUri: string,
+  existingMandataris: string | undefined | null,
+) => {
+  if (existingMandataris) {
+    // we can copy over the existing values for the new burgemeester from the previous mandataris
+    return await copyFromPreviousMandataris(
+      orgGraph,
+      existingMandataris,
+      date,
+      burgemeesterMandaatUri,
+    );
   } else {
     // we need to create a new mandataris from scratch
-    newMandatarisUri = await createBurgemeesterFromScratch(
+    return await createBurgemeesterFromScratch(
       orgGraph,
-      burgemeesterUri,
+      burgemeesterPersoonUri,
       burgemeesterMandaatUri,
       date,
       benoemingUri,
     );
   }
+};
+
+const handleLinkedMandatarisBurgemeester = async (
+  orgGraph: string,
+  newBurgemeesterUri: string,
+  date: Date,
+  benoemingUri: string,
+  existingMandataris: string | undefined | null,
+) => {
+  // TODO
+};
+
+const transferAangewezenBurgemeesterToBurgemeester = async (
+  orgGraph: string,
+  burgemeesterPersoonUri: string,
+  burgemeesterMandaatUri: string,
+  date: Date,
+  benoemingUri: string,
+  existingMandataris: string | undefined | null,
+) => {
+  await handleAangewezenBurgemeester(
+    orgGraph,
+    existingMandataris,
+    date,
+    benoemingUri,
+  );
+
+  const newMandatarisUri = await handleBurgemeester(
+    orgGraph,
+    burgemeesterPersoonUri,
+    burgemeesterMandaatUri,
+    date,
+    benoemingUri,
+    existingMandataris,
+  );
+
+  handleLinkedMandatarisBurgemeester(
+    orgGraph,
+    newMandatarisUri,
+    date,
+    benoemingUri,
+    existingMandataris,
+  );
+
   addBenoemingTriple(
     orgGraph,
     newMandatarisUri,

--- a/controllers/burgemeester-benoeming.ts
+++ b/controllers/burgemeester-benoeming.ts
@@ -151,7 +151,7 @@ const handleBurgemeester = async (
   }
 
   // Check if burgemeester exists for another person
-  const otherBurgemeesterFound = otherPersonHasMandate(
+  const otherBurgemeesterFound = await otherPersonHasMandate(
     orgGraph,
     burgemeesterPersoonUri,
     burgemeesterMandaatUri,
@@ -160,7 +160,7 @@ const handleBurgemeester = async (
 
   // If so create notification
   if (otherBurgemeesterFound) {
-    createNotificationMultipleBurgemeesters(orgGraph);
+    createNotificationMultipleBurgemeesters(orgGraph, otherBurgemeesterFound);
   }
 
   if (existingMandataris) {

--- a/controllers/linked-mandataris.ts
+++ b/controllers/linked-mandataris.ts
@@ -329,6 +329,10 @@ export const getOrCreateOnafhankelijkeFractie = async (
   return await copyOnafhankelijkeFractieOfMandataris(mandatarisId, graph);
 };
 
+export const getLinkedMandates = () => {
+  return getValueBindings(linkedMandaten);
+};
+
 function getValueBindings(mapping) {
   const stringArray: string[] = [];
   mapping.forEach((value, key) => {

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -318,3 +318,22 @@ export const createNotificationMultipleBurgemeesters = async (
     ],
   });
 };
+
+export const createNotificationAfgewezenBurgemeester = async (
+  graph: string,
+  mandatarisUri: string,
+) => {
+  await createNotification({
+    title: 'Burgemeester werd afgewezen',
+    description:
+      'De burgemeester werd afgewezen, gelieve een nieuwe burgemeester aan te stellen en deze wijzigingen ook door the voeren in het OCMW.',
+    type: 'info',
+    graph: graph,
+    links: [
+      {
+        type: 'mandataris',
+        uri: mandatarisUri,
+      },
+    ],
+  });
+};

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -319,6 +319,25 @@ export const createNotificationOtherPersonWithBurgemeesterMandaat = async (
   });
 };
 
+export const createNotificationMultipleAangesteldeBurgemeesters = async (
+  graph: string,
+  mandatarisUris: string[],
+) => {
+  await createNotification({
+    title: 'Meerder burgemeester werden benoemd',
+    description:
+      'De benoeming van de burgemeester werd succesvol verwerkt, deze persoon had echter meerdere burgemeester mandaten, dus zijn alle benoemd.',
+    type: 'info',
+    graph: graph,
+    links: mandatarisUris.map((mandataris) => {
+      return {
+        type: 'mandataris',
+        uri: mandataris,
+      };
+    }),
+  });
+};
+
 export const createNotificationAangesteldeBurgemeester = async (
   graph: string,
   mandatarisUri: string,

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -8,6 +8,7 @@ import {
   getBooleanSparqlResult,
 } from '../util/sparql-result';
 import { BENOEMING_STATUS, PUBLICATION_STATUS } from '../util/constants';
+import { createNotification } from '../util/create-notification';
 
 export async function isBestuurseenheidDistrict(
   bestuurseenheidUri: string,
@@ -296,4 +297,23 @@ export const setPublicationSatusWithDate = async (
     }
 `;
   await updateSudo(updateQuery);
+};
+
+export const createNotificationMultipleBurgemeesters = async (
+  graph: string,
+  mandatarisUri: string,
+) => {
+  await createNotification({
+    title: 'Andere burgemeester gevonden die niet benoemd is',
+    description:
+      'Bij het benoemen van de burgemeester werd een andere persoon gevonden met het burgemeester mandaat. Gelieve dit na te kijken.',
+    type: 'warning',
+    graph: graph,
+    links: [
+      {
+        type: 'mandataris',
+        uri: mandatarisUri,
+      },
+    ],
+  });
 };

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -319,6 +319,25 @@ export const createNotificationMultipleBurgemeesters = async (
   });
 };
 
+export const createNotificationAangesteldeBurgemeester = async (
+  graph: string,
+  mandatarisUri: string,
+) => {
+  await createNotification({
+    title: 'Burgemeester werd benoemd',
+    description:
+      'De benoeming van de burgemeester werd succesvol verwerkt, deze burgemeester is nu bekrachtigd.',
+    type: 'info',
+    graph: graph,
+    links: [
+      {
+        type: 'mandataris',
+        uri: mandatarisUri,
+      },
+    ],
+  });
+};
+
 export const createNotificationAfgewezenBurgemeester = async (
   graph: string,
   mandatarisUri: string,

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -300,7 +300,7 @@ export const setPublicationStatusWithDate = async (
   await updateSudo(updateQuery);
 };
 
-export const createNotificationMultipleBurgemeesters = async (
+export const createNotificationOtherPersonWithBurgemeesterMandaat = async (
   graph: string,
   mandatarisUri: string,
 ) => {

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -176,3 +176,39 @@ export const addBenoemingTriple = async (
       }
     }`);
 };
+
+export const getPersoonMandaatMandataris = async (
+  graph: string,
+  persoonUri: string,
+  mandaatUri: string,
+  date: Date,
+) => {
+  const escaped = {
+    graph: sparqlEscapeUri(graph),
+    persoonUri: sparqlEscapeUri(persoonUri),
+    mandaatUri: sparqlEscapeUri(mandaatUri),
+    date: sparqlEscapeDateTime(date),
+  };
+  const selectQuery = `
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT DISTINCT ?mandataris WHERE {
+      GRAPH ${escaped.graph} {
+        ?mandataris a mandaat:Mandataris ;
+          org:holds ?mandaat ;
+          mandaat:isBestuurlijkeAliasVan ?persoon ;
+          mandaat:start ?start .
+        OPTIONAL {
+          ?mandataris mandaat:einde ?einde .
+        }
+        BIND(IF(BOUND(?einde), ?einde, "3000-01-01"^^xsd:dateTime) AS ?safeEinde)
+        FILTER(?start <= ${escaped.date} && ?safeEinde > ${escaped.date})
+      }
+      VALUES ?persoon { ${escaped.persoonUri} }
+      VALUES ?mandaat { ${escaped.mandaatUri} }
+    }
+  `;
+  const result = await querySudo(selectQuery);
+  return findFirstSparqlResult(result);
+};

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -252,20 +252,18 @@ export const otherPersonHasMandate = async (
   return findFirstSparqlResult(result)?.mandataris?.value;
 };
 
-export const setPublicationSatusWithDate = async (
+export const setPublicationStatusWithDate = async (
   graph: string,
-  mandatarissen: string[],
+  mandataris: string,
   date: Date,
   status: PUBLICATION_STATUS,
 ) => {
   const escaped = {
     graph: sparqlEscapeUri(graph),
+    mandataris: sparqlEscapeUri(mandataris),
     date: sparqlEscapeDateTime(date),
     status: sparqlEscapeUri(status),
   };
-  const safeMandatarissen = mandatarissen
-    .map((mandataris) => sparqlEscapeUri(mandataris))
-    .join('\n');
   const updateQuery = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -296,9 +294,7 @@ export const setPublicationSatusWithDate = async (
         }
         BIND(NOW() as ?now)
       }
-      VALUES ?mandataris {
-        ${safeMandatarissen}
-      }
+      VALUES ?mandataris { ${escaped.mandataris} }
     }
 `;
   await updateSudo(updateQuery);

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -248,7 +248,7 @@ export const otherPersonHasMandate = async (
     }
   `;
   const result = await querySudo(selectQuery);
-  return findFirstSparqlResult(result);
+  return findFirstSparqlResult(result)?.mandataris?.value;
 };
 
 export const setPublicationSatusWithDate = async (

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -726,6 +726,62 @@ export async function unlinkInstance(instance: string) {
   await updateSudo(query);
 }
 
+export async function linkInstancesOnUri(instance1: string, instance2: string) {
+  const insertQuery = `
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+    INSERT {
+      GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
+        ?i1 ext:linked ?i2 .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ?i1 mu:uuid ?id1 .
+      }
+      GRAPH ?h {
+        ?i2 mu:uuid ?id2 .
+      }
+      VALUES ?i1 { ${sparqlEscapeUri(instance1)} }
+      VALUES ?i2 { ${sparqlEscapeUri(instance2)} }
+    }
+  `;
+
+  await updateSudo(insertQuery);
+}
+
+export async function unlinkInstanceOnUri(instance: string) {
+  const query = `
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+    DELETE {
+      GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
+        ?i1 ext:linked ?i2 .
+        ?i2 ext:linked ?i1 .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ?i1 mu:uuid ?id1 .
+      }
+      GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
+        {
+          ?i1 ext:linked ?i2 .
+        }
+        UNION
+        {
+          ?i2 ext:linked ?i1 .
+        }
+      }
+      VALUES ?i1 { ${sparqlEscapeUri(instance)} }
+    }
+  `;
+
+  await updateSudo(query);
+}
+
 export async function findLinkedInstance(instance1: string) {
   const query = `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>


### PR DESCRIPTION
## Description

Improve flow of burgemeester benoeming.

If an aangewezen Burgemeester exists this one gets terminated.
If a corresponding burgemeester exists this one gets bekrachtigd. 
If another person is burgemeester a notification is generated.
If the person does not have a burgemeester mandate, a new one is created.

Linked mandates are not used anymore.

## How to test

Will try to add a bruno collection, but my debugger is broken, so I can't really confirm everything works.
You should test 5 cases:
- Try to benoem a person that has no burgemeester mandate yet
- Try to benoem a person that has a burgemeester mandate
- Try to benoem a person that has multiple active burgemeester mandates
- Try to benoem a person while another person has a burgemeester mandate
- Try to reject a person 

See if all these use cases make sense.
Testing is a bit difficult, you need to go to a bestuurseenheid where you can find this state (easiest to just add some mandatarissen manually) and then you can try the bruno call.

You will need to add authentication details. I added "test" as password, just fill in the correct one(you can temporarily add a new key) or you can search the vendor key in the database.