### PR TITLE
fix count mandatarissen

### DIFF
--- a/data-access/orgaan.ts
+++ b/data-access/orgaan.ts
@@ -32,9 +32,13 @@ export async function getActivePersonen(bestuursorgaanId: string) {
    }`;
 
   const effectiveEndDateResult = await query(effectiveEndDateQuery);
-  const effectiveEndDate =
+  let effectiveEndDate =
     effectiveEndDateResult?.results?.bindings[0]?.effectiveEndDate?.value ||
     new Date();
+  if (moment(effectiveEndDate).isAfter(new Date())) {
+    // if the end date is in the future, it means we are looking at the current organ. Return the currently active mandatarissen
+    effectiveEndDate = new Date();
+  }
   // especially old data has incorrect hours in their end date. Let's give ourselves two hours of margin
   const effectiveEndDateWithMargin = moment(effectiveEndDate)
     .subtract(2, 'hours')


### PR DESCRIPTION
## Description

when asking for an orgaan with mandatarissen in the future, it means we want the currently active mandatarissen. In that case use the current date instead of the last mandataris date (people put end dates in the future and end mandatarissen early, which results in a count that is too low sometimes)
## How to test

View the count for Boechout, it should now be correct