### PR TITLE
when deleting, allow delete of linked mandataris too

### DIFF
--- a/data-access/delete.ts
+++ b/data-access/delete.ts
@@ -1,4 +1,8 @@
 import { query, sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
+import { updateSudo } from '@lblod/mu-auth-sudo';
+import { areIdsValid, RDF_TYPE } from '../util/valid-id';
+import { HttpError } from '../util/http-error';
+import { findLinkedInstance } from './linked-mandataris';
 
 export const deleteInstanceWithTombstone = async (id: string) => {
   const now = new Date();
@@ -23,4 +27,63 @@ export const deleteInstanceWithTombstone = async (id: string) => {
   }
   `;
   await query(q);
+};
+
+export const deleteMandatarisWithTombstone = async (
+  id: string,
+  removeLinked: boolean,
+) => {
+  const canAccessMandataris = areIdsValid(RDF_TYPE.MANDATARIS, [id]);
+  if (!canAccessMandataris) {
+    throw new HttpError('No mandataris with given id found', 404);
+  }
+
+  const ids = [id];
+  if (removeLinked) {
+    const linked = await findLinkedInstance(id);
+    if (linked && linked.id) {
+      ids.push(linked.id);
+    }
+  }
+
+  const safeIds = ids.map((id) => sparqlEscapeString(id)).join('\n');
+
+  const now = new Date();
+  const q = `
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  PREFIX astreams: <http://www.w3.org/ns/activitystreams#>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+  DELETE {
+    GRAPH ?g {
+      ?uri ?p ?o.
+      ?other mandaat:isTijdelijkVervangenDoor ?uri.
+    }
+  }
+  INSERT {
+    GRAPH ?g {
+      ?uri a astreams:Tombstone ;
+         astreams:deleted ${sparqlEscapeDateTime(now)} ;
+         dct:modified ${sparqlEscapeDateTime(now)} ;
+         astreams:formerType ?type .
+    }
+  }
+  WHERE {
+    VALUES ?id {
+      ${safeIds}
+    }
+    GRAPH ?g {
+      ?uri mu:uuid ?id ;
+         a ?type ;
+         ?p ?o .
+      OPTIONAL {
+        ?other mandaat:isTijdelijkVervangenDoor ?uri.
+      }
+    }
+    ?g ext:ownedBy ?someone.
+  }
+  `;
+  await updateSudo(q);
 };

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -694,6 +694,8 @@ export async function findLinkedInstance(instance1: string) {
       GRAPH ?h {
         ?i2Uri mu:uuid ?i2Id .
       }
+      ?g ext:ownedBy ?someone.
+      ?h ext:ownedBy ?someoneElse.
     }
     LIMIT 1
   `;

--- a/routes/mandatarissen.ts
+++ b/routes/mandatarissen.ts
@@ -5,7 +5,7 @@ import multer from 'multer';
 
 import { mandatarisDownloadRequest } from '../Requests/mandataris-download';
 
-import { deleteInstanceWithTombstone } from '../data-access/delete';
+import { deleteMandatarisWithTombstone } from '../data-access/delete';
 
 import {
   addLinkLinkedMandataris,
@@ -31,7 +31,8 @@ const upload = multer({ dest: 'mandataris-uploads/' });
 const mandatarissenRouter = Router();
 
 mandatarissenRouter.delete('/:id', async (req: Request, res: Response) => {
-  await deleteInstanceWithTombstone(req.params.id);
+  const withLinked = req.query.withLinked === 'true';
+  await deleteMandatarisWithTombstone(req.params.id, withLinked);
   return res.status(204).send();
 });
 


### PR DESCRIPTION

## Description

when deleting, allow delete of linked mandataris too
extra safety when checking on linked mandataris, needs to be still known in owned graph

## How to test

see linked pr
## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/490