### PR TITLE
Lmb 1407 | Soft removal draft publication status

### DIFF
--- a/controllers/mandataris.ts
+++ b/controllers/mandataris.ts
@@ -8,7 +8,7 @@ import {
 import { persoon } from '../data-access/persoon';
 import { saveBulkHistoryItem } from '../data-access/form-queries';
 
-import { STATUS_CODE } from '../util/constants';
+import { PUBLICATION_STATUS, STATUS_CODE } from '../util/constants';
 import { HttpError } from '../util/http-error';
 import { createRangorde } from '../util/rangorde';
 
@@ -161,7 +161,7 @@ async function copyOverNonResourceDomainPredicates(
 
 export async function handleBulkSetPublicationStatus(
   mandatarissen: string[],
-  status: string,
+  statusUri: string,
   link?: string,
 ): Promise<void> {
   if (!mandatarissen || mandatarissen.length == 0) {
@@ -177,11 +177,11 @@ export async function handleBulkSetPublicationStatus(
     throw new HttpError('Unauthorized', 401);
   }
 
-  if (status == 'Niet bekrachtigd') {
+  if (statusUri === PUBLICATION_STATUS.NIET_BEKRACHTIGD) {
     await bulkSetPublicationStatusNietBekrachtigd(mandatarissen);
     return;
   }
-  if (status == 'Bekrachtigd') {
+  if (statusUri === PUBLICATION_STATUS.BEKRACHTIGD) {
     if (!link) {
       throw new HttpError(
         'No link to publication was provided',
@@ -192,7 +192,7 @@ export async function handleBulkSetPublicationStatus(
     return;
   }
   throw new HttpError(
-    `The provided status: ${status} is not a valid publication status, please provide "Niet bekrachtigd" or "Bekrachtigd".`,
+    `The provided status: ${statusUri} is not a valid publication status, please provide a correct publication status uri.`,
     STATUS_CODE.BAD_REQUEST,
   );
 }

--- a/controllers/mandataris.ts
+++ b/controllers/mandataris.ts
@@ -1,8 +1,8 @@
 import { fractie } from '../data-access/fractie';
 import {
   bulkBekrachtigMandatarissen,
-  bulkSetPublicationStatusEffectief,
   checkMandatarisOwnershipQuery,
+  bulkSetPublicationStatusNietBekrachtigd,
   mandataris,
 } from '../data-access/mandataris';
 import { persoon } from '../data-access/persoon';
@@ -177,8 +177,8 @@ export async function handleBulkSetPublicationStatus(
     throw new HttpError('Unauthorized', 401);
   }
 
-  if (status == 'Effectief') {
-    await bulkSetPublicationStatusEffectief(mandatarissen);
+  if (status == 'Niet bekrachtigd') {
+    await bulkSetPublicationStatusNietBekrachtigd(mandatarissen);
     return;
   }
   if (status == 'Bekrachtigd') {
@@ -192,7 +192,7 @@ export async function handleBulkSetPublicationStatus(
     return;
   }
   throw new HttpError(
-    `The provided status: ${status} is not a valid publication status, please provide Effectief or Bekrachtigd.`,
+    `The provided status: ${status} is not a valid publication status, please provide "Niet bekrachtigd" or "Bekrachtigd".`,
     STATUS_CODE.BAD_REQUEST,
   );
 }

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -103,7 +103,7 @@ async function getContactEmailForMandataris(mandatarisUri?: string) {
 async function fetchEffectiveMandatarissenWithoutBesluitAndNotification() {
   const momentTenDaysAgo = moment(new Date()).subtract(10, 'days');
   const escapedTenDaysBefore = sparqlEscapeDateTime(momentTenDaysAgo.toDate());
-  const escapedEffectiefStatus = sparqlEscapeUri(PUBLICATION_STATUS.EFFECTIEF);
+  const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
   const query = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -119,7 +119,7 @@ async function fetchEffectiveMandatarissenWithoutBesluitAndNotification() {
       WHERE {
         GRAPH ?graph {
           ?mandataris a mandaat:Mandataris ;
-            lmb:hasPublicationStatus ${escapedEffectiefStatus} ;
+            lmb:hasPublicationStatus ${nietBekrachtigd} ;
             mandaat:isBestuurlijkeAliasVan ?person ;
             org:holds / org:role ?bestuursfunctie .
           ?person persoon:gebruikteVoornaam ?fName ;

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -128,11 +128,11 @@ export const createBurgemeesterFromScratch = async (
   const newMandatarisUri = `http://data.lblod.info/id/mandatarissen/${uuid}`;
   const formattedNewMandatarisUri = sparqlEscapeUri(newMandatarisUri);
   const escapedBenoemingUri = sparqlEscapeUri(benoemingUri);
-  const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
   await updateSudo(`
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX mps: <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/>
     PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
     PREFIX org: <http://www.w3.org/ns/org#>
 
@@ -144,7 +144,7 @@ export const createBurgemeesterFromScratch = async (
           mandaat:isBestuurlijkeAliasVan ${sparqlEscapeUri(burgemeesterUri)} ;
           mandaat:start ${sparqlEscapeDateTime(date)} ;
           mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> ;
-          lmb:hasPublicationStatus ${nietBekrachtigd} .
+          lmb:hasPublicationStatus mps:9d8fd14d-95d0-4f5e-b3a5-a56a126227b6 .
         ${escapedBenoemingUri} ext:approves ${formattedNewMandatarisUri} .
       }
     }`);

--- a/data-access/burgemeester.ts
+++ b/data-access/burgemeester.ts
@@ -128,11 +128,11 @@ export const createBurgemeesterFromScratch = async (
   const newMandatarisUri = `http://data.lblod.info/id/mandatarissen/${uuid}`;
   const formattedNewMandatarisUri = sparqlEscapeUri(newMandatarisUri);
   const escapedBenoemingUri = sparqlEscapeUri(benoemingUri);
+  const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
   await updateSudo(`
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX mps: <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/>
     PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
     PREFIX org: <http://www.w3.org/ns/org#>
 
@@ -144,7 +144,7 @@ export const createBurgemeesterFromScratch = async (
           mandaat:isBestuurlijkeAliasVan ${sparqlEscapeUri(burgemeesterUri)} ;
           mandaat:start ${sparqlEscapeDateTime(date)} ;
           mandaat:status <http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75> ;
-          lmb:hasPublicationStatus mps:9d8fd14d-95d0-4f5e-b3a5-a56a126227b6 .
+          lmb:hasPublicationStatus ${nietBekrachtigd} .
         ${escapedBenoemingUri} ext:approves ${formattedNewMandatarisUri} .
       }
     }`);

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -1,13 +1,15 @@
-import { HttpError } from '../util/http-error';
 import { query, sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import { updateSudo, querySudo } from '@lblod/mu-auth-sudo';
+import { v4 as uuidv4 } from 'uuid';
+
+import { HttpError } from '../util/http-error';
 import {
   findFirstSparqlResult,
   getBooleanSparqlResult,
 } from '../util/sparql-result';
-import { v4 as uuidv4 } from 'uuid';
 import { instanceIdentifiers } from '../types';
 import { createNotification } from '../util/create-notification';
+import { PUBLICATION_STATUS } from '../util/constants';
 
 export async function canAccessMandataris(id: string) {
   const sparql = `
@@ -478,6 +480,7 @@ export async function createNewLinkedMandataris(
     newMandatarisUuid: sparqlEscapeString(newMandatarisUuid),
     newMandataris: sparqlEscapeUri(newMandatarisUri),
     graph: sparqlEscapeUri(graph),
+    publicationStatus: sparqlEscapeUri(PUBLICATION_STATUS.EFFECTIEF),
   };
   let fractieTriples = '';
   if (fractieUri) {
@@ -508,7 +511,7 @@ export async function createNewLinkedMandataris(
         ${escaped.newMandataris} a mandaat:Mandataris ;
           mu:uuid ${escaped.newMandatarisUuid} ;
           org:holds ?linkedMandaat ;
-          lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07> ;
+          lmb:hasPublicationStatus ${escaped.publicationStatus} ;
           ?mandatarisp ?mandatariso .
         ${fractieTriples}
       }

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -480,7 +480,7 @@ export async function createNewLinkedMandataris(
     newMandatarisUuid: sparqlEscapeString(newMandatarisUuid),
     newMandataris: sparqlEscapeUri(newMandatarisUri),
     graph: sparqlEscapeUri(graph),
-    publicationStatus: sparqlEscapeUri(PUBLICATION_STATUS.EFFECTIEF),
+    nietBekrachtigd: sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD),
   };
   let fractieTriples = '';
   if (fractieUri) {
@@ -511,7 +511,7 @@ export async function createNewLinkedMandataris(
         ${escaped.newMandataris} a mandaat:Mandataris ;
           mu:uuid ${escaped.newMandatarisUuid} ;
           org:holds ?linkedMandaat ;
-          lmb:hasPublicationStatus ${escaped.publicationStatus} ;
+          lmb:hasPublicationStatus ${escaped.nietBekrachtigd} ;
           ?mandatarisp ?mandatariso .
         ${fractieTriples}
       }

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -838,7 +838,7 @@ async function generateMandatarissen(
     endDate: sparqlEscapeDateTime(endDate),
     mandaat: sparqlEscapeUri(mandaatUri),
     effectief: sparqlEscapeUri(MANDATARIS_STATUS.EFFECTIEF),
-    nietBekrachtigd: sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD),
+    publication: sparqlEscapeUri(PUBLICATION_STATUS.DRAFT),
   };
 
   const createQuery = `
@@ -860,7 +860,7 @@ async function generateMandatarissen(
           ${endDate ? `mandaat:einde ${escapedCommon.endDate};` : ''}
           org:holds ${escapedCommon.mandaat} ;
           mandaat:status ${escapedCommon.effectief} ;
-          lmb:hasPublicationStatus ${escapedCommon.nietBekrachtigd} .
+          lmb:hasPublicationStatus ${escapedCommon.publication} .
       }
     }
     WHERE {

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -583,7 +583,7 @@ export async function updatePublicationStatusOfMandataris(
   }
 }
 
-export async function bulkSetPublicationStatusEffectief(
+export async function bulkSetPublicationStatusNietBekrachtigd(
   mandatarissen: string[],
 ): Promise<void> {
   const escaped = {
@@ -838,7 +838,7 @@ async function generateMandatarissen(
     endDate: sparqlEscapeDateTime(endDate),
     mandaat: sparqlEscapeUri(mandaatUri),
     effectief: sparqlEscapeUri(MANDATARIS_STATUS.EFFECTIEF),
-    publication: sparqlEscapeUri(PUBLICATION_STATUS.DRAFT),
+    nietBekrachtigd: sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD),
   };
 
   const createQuery = `
@@ -860,7 +860,7 @@ async function generateMandatarissen(
           ${endDate ? `mandaat:einde ${escapedCommon.endDate};` : ''}
           org:holds ${escapedCommon.mandaat} ;
           mandaat:status ${escapedCommon.effectief} ;
-          lmb:hasPublicationStatus ${escapedCommon.publication} .
+          lmb:hasPublicationStatus ${escapedCommon.nietBekrachtigd} .
       }
     }
     WHERE {

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -590,7 +590,7 @@ export async function bulkSetPublicationStatusEffectief(
     mandatarissenUuids: mandatarissen
       .map((uri) => sparqlEscapeString(uri))
       .join(' '),
-    effectief: sparqlEscapeUri(PUBLICATION_STATUS.EFFECTIEF),
+    nietBekrachtigd: sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD),
     bekrachtigd: sparqlEscapeUri(PUBLICATION_STATUS.BEKRACHTIGD),
     todaysDate: sparqlEscapeDateTime(new Date()),
   };
@@ -607,7 +607,7 @@ export async function bulkSetPublicationStatusEffectief(
     }
     INSERT {
       GRAPH ?graph {
-        ?mandataris lmb:hasPublicationStatus ${escaped.effectief} .
+        ?mandataris lmb:hasPublicationStatus ${escaped.nietBekrachtigd} .
         ?mandataris lmb:effectiefAt ${escaped.todaysDate} .
       }
     }

--- a/data-access/orgaan.ts
+++ b/data-access/orgaan.ts
@@ -9,7 +9,7 @@ import moment from 'moment';
 import { PUBLICATION_STATUS } from '../util/constants';
 
 export async function getActivePersonen(bestuursorgaanId: string) {
-  const draftPublicatieStatus = sparqlEscapeUri(PUBLICATION_STATUS.DRAFT);
+  const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
   const safeStatussen = [
     sparqlEscapeUri(
       'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75', // Effectief
@@ -66,7 +66,7 @@ export async function getActivePersonen(bestuursorgaanId: string) {
       }
 
       FILTER NOT EXISTS {
-        ?mandataris lmb:hasPublicationStatus ${draftPublicatieStatus} .
+        ?mandataris lmb:hasPublicationStatus ${nietBekrachtigd} .
       }
       VALUES ?dateToCheck {
         ${sparqlEscapeDateTime(effectiveEndDateWithMargin)}

--- a/data-access/orgaan.ts
+++ b/data-access/orgaan.ts
@@ -9,7 +9,7 @@ import moment from 'moment';
 import { PUBLICATION_STATUS } from '../util/constants';
 
 export async function getActivePersonen(bestuursorgaanId: string) {
-  const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
+  const draftPublicationStatus = sparqlEscapeUri(PUBLICATION_STATUS.DRAFT);
   const safeStatussen = [
     sparqlEscapeUri(
       'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75', // Effectief
@@ -66,7 +66,7 @@ export async function getActivePersonen(bestuursorgaanId: string) {
       }
 
       FILTER NOT EXISTS {
-        ?mandataris lmb:hasPublicationStatus ${nietBekrachtigd} .
+        ?mandataris lmb:hasPublicationStatus ${draftPublicationStatus} .
       }
       VALUES ?dateToCheck {
         ${sparqlEscapeDateTime(effectiveEndDateWithMargin)}

--- a/routes/installatievergadering.ts
+++ b/routes/installatievergadering.ts
@@ -17,6 +17,7 @@ import {
   GEMEENTERAADSLID_FUNCTIE_CODE,
   LID_OCMW_FUNCTIE_CODE,
   LID_VB_FUNCTIE_CODE,
+  PUBLICATION_STATUS,
   SCHEPEN_FUNCTIE_CODE,
   TOEGEVOEGDE_SCHEPEN_FUNCTIE_CODE,
   VOORZITTER_GEMEENTERAAD_FUNCTIE_CODE,
@@ -52,7 +53,7 @@ installatievergaderingRouter.post(
     await moveOcmwOrgans(installatievergaderingId);
     await movePersons(installatievergaderingId);
     await setLinkedIVToBehandeld(installatievergaderingId);
-    await setMandatarisenToEffectief(installatievergaderingId);
+    await setMandatarissenToNietBekrachtigd(installatievergaderingId);
     return res.status(200).send({ status: 'ok' });
   },
 );
@@ -421,8 +422,9 @@ async function movePersons(installatievergaderingId: string) {
   await updateSudo(sparql);
 }
 
-async function setMandatarisenToEffectief(installatievergaderingId) {
+async function setMandatarissenToNietBekrachtigd(installatievergaderingId) {
   const escapedId = sparqlEscapeString(installatievergaderingId);
+  const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
   const sparql = `
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -446,7 +448,7 @@ async function setMandatarisenToEffectief(installatievergaderingId) {
   }
   INSERT {
     GRAPH ?target {
-      ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188>.
+      ?mandataris lmb:hasPublicationStatus ${nietBekrachtigd} .
       ?mandataris lmb:effectiefAt ?now.
       ?mandataris dct:modified ?now.
     }

--- a/routes/mandatarissen.ts
+++ b/routes/mandatarissen.ts
@@ -203,10 +203,10 @@ mandatarissenRouter.put(
 mandatarissenRouter.post(
   '/bulk-set-publication-status/',
   async (req: Request, res: Response) => {
-    const { decision, status, mandatarissen } = req.body;
+    const { decision, statusUri, mandatarissen } = req.body;
 
     try {
-      await handleBulkSetPublicationStatus(mandatarissen, status, decision);
+      await handleBulkSetPublicationStatus(mandatarissen, statusUri, decision);
       return res.status(200).send({ status: 'ok' });
     } catch (error) {
       const message =

--- a/routes/rangorde.ts
+++ b/routes/rangorde.ts
@@ -273,9 +273,7 @@ async function insertNewMandatarisData(
       return `( ${safeUri} ${safeNewUuid} ${safeRangorde} )`;
     })
     .join('\n');
-  const nietBekrachtigd = sparqlEscapeUri(
-    sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD),
-  );
+  const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
   const updateQuery = `
       PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

--- a/routes/rangorde.ts
+++ b/routes/rangorde.ts
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Request, Response } from 'express';
 
-import { STATUS_CODE } from '../util/constants';
+import { PUBLICATION_STATUS, STATUS_CODE } from '../util/constants';
 import { HttpError } from '../util/http-error';
 import { sparqlEscapeQueryBinding } from '../util/sparql-escape';
 
@@ -273,7 +273,9 @@ async function insertNewMandatarisData(
       return `( ${safeUri} ${safeNewUuid} ${safeRangorde} )`;
     })
     .join('\n');
-
+  const publicationStatus = sparqlEscapeUri(
+    sparqlEscapeUri(PUBLICATION_STATUS.EFFECTIEF),
+  );
   const updateQuery = `
       PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -284,7 +286,7 @@ async function insertNewMandatarisData(
         GRAPH ?g {
           ?mandataris mu:uuid ?newUuid .
           ?mandataris mandaat:rangorde ?rangorde .
-          ?mandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07> .
+          ?mandataris lmb:hasPublicationStatus ${publicationStatus} .
           ?mandataris mandaat:start ${sparqlEscapeDateTime(date)} .
         }
       } WHERE {

--- a/routes/rangorde.ts
+++ b/routes/rangorde.ts
@@ -273,8 +273,8 @@ async function insertNewMandatarisData(
       return `( ${safeUri} ${safeNewUuid} ${safeRangorde} )`;
     })
     .join('\n');
-  const publicationStatus = sparqlEscapeUri(
-    sparqlEscapeUri(PUBLICATION_STATUS.EFFECTIEF),
+  const nietBekrachtigd = sparqlEscapeUri(
+    sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD),
   );
   const updateQuery = `
       PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
@@ -286,7 +286,7 @@ async function insertNewMandatarisData(
         GRAPH ?g {
           ?mandataris mu:uuid ?newUuid .
           ?mandataris mandaat:rangorde ?rangorde .
-          ?mandataris lmb:hasPublicationStatus ${publicationStatus} .
+          ?mandataris lmb:hasPublicationStatus ${nietBekrachtigd} .
           ?mandataris mandaat:start ${sparqlEscapeDateTime(date)} .
         }
       } WHERE {

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -4,7 +4,7 @@ export enum MANDATARIS_STATUS {
 
 export enum PUBLICATION_STATUS {
   DRAFT = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07',
-  EFFECTIEF = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188',
+  EFFECTIEF = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188', // Renamed to 'niet bekrachtigd'
   BEKRACHTIGD = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6',
 }
 

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -4,7 +4,7 @@ export enum MANDATARIS_STATUS {
 
 export enum PUBLICATION_STATUS {
   DRAFT = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07',
-  NIET_BEKRACHTIGD = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188', // Renamed to 'niet bekrachtigd'
+  NIET_BEKRACHTIGD = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188',
   BEKRACHTIGD = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6',
 }
 

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -4,7 +4,7 @@ export enum MANDATARIS_STATUS {
 
 export enum PUBLICATION_STATUS {
   DRAFT = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07',
-  EFFECTIEF = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188', // Renamed to 'niet bekrachtigd'
+  NIET_BEKRACHTIGD = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188', // Renamed to 'niet bekrachtigd'
   BEKRACHTIGD = 'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6',
 }
 

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -2,6 +2,9 @@ import { v4 as uuid } from 'uuid';
 import { sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
 import { updateSudo } from '@lblod/mu-auth-sudo';
 
+// These notifications/emails are not sent atm
+// A ticket was created to update this logic
+// TODO: update all effectief to be Niet bekrachtigd
 const EMAIL_FROM_MANDATARIS_EFFECTIEF =
   process.env.EMAIL_FROM_MANDATARIS_EFFECTIEF;
 export const SEND_EMAILS =
@@ -35,7 +38,7 @@ export async function sendMissingBekrachtigingsmail(
   const to = sparqlEscapeString(emailTo);
   const htmlMessage = `
     <p>Beste,</p>
-    <p>Er zijn een aantal mandatarissen die al meer dan 10 dagen de publicatiestatus ‘Effectief’ hebben zonder koppeling met een besluit. Voor uw gemeente zijn dit er ${mandatarissen.length}.</p>
+    <p>Er zijn een aantal mandatarissen die al meer dan 10 dagen de publicatiestatus ‘Niet bekrachtigd’ hebben zonder koppeling met een besluit. Voor uw gemeente zijn dit er ${mandatarissen.length}.</p>
     <p> Hieronder vindt u een overzicht van al deze mandatarissen: <p>
     <table>
       <tr>


### PR DESCRIPTION
## Description

When a new mandataris is created it needs to start in niet bekrachtigd publication status. Mandatarissen for IV should start in draft status. 

Renamed the constant, method names, etc..

TODO: but for the ticket where we fix the notifications/emails 

## How to test

Togheter with the frontend.

1. create a linked mandataris
2. Generated mandatarissen in IV

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/500
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/386
