### PR TITLE
Ben/lmb 1429 fix empty export

### DIFF
--- a/controllers/mandataris-download.ts
+++ b/controllers/mandataris-download.ts
@@ -99,22 +99,22 @@ function getSortingPropertyForQuery(sort?: string) {
   sort = sort ? sort : 'is-bestuurlijke-alias-van.achternaam';
 
   const mapping = {
-    'is-bestuurlijke-alias-van.gebruikte-voornaam': '?fName',
-    '-is-bestuurlijke-alias-van.gebruikte-voornaam': '?fName',
-    'is-bestuurlijke-alias-van.achternaam': '?saveLName',
-    '-is-bestuurlijke-alias-van.achternaam': '?saveLName',
+    'is-bestuurlijke-alias-van.gebruikte-voornaam': '?Voornaam',
+    '-is-bestuurlijke-alias-van.gebruikte-voornaam': '?Voornaam',
+    'is-bestuurlijke-alias-van.achternaam': '?Naam',
+    '-is-bestuurlijke-alias-van.achternaam': '?Naam',
     'heeft-lidmaatschap.binnen-fractie.naam': '?fractieLabel',
     '-heeft-lidmaatschap.binnen-fractie.naam': '?fractieLabel',
     'bekleedt.bestuursfunctie.label': '?mandaatLabel',
     '-bekleedt.bestuursfunctie.label': '?mandaatLabel',
     start: '?start',
     '-start': '?start',
-    einde: '?saveEinde',
-    '-einde': '?saveEinde',
+    einde: '?einde',
+    '-einde': '?einde',
     'status.label': '?statusLabel',
     '-status.label': '?statusLabel',
-    'publication-status': '?savePublicatieStatusLabel',
-    '-publication-status': '?savePublicatieStatusLabel',
+    'publication-status': '?publicatieStatusLabel',
+    '-publication-status': '?publicatieStatusLabel',
   };
 
   if (!Object.keys(mapping).includes(sort)) {

--- a/controllers/mandataris-download.ts
+++ b/controllers/mandataris-download.ts
@@ -96,9 +96,7 @@ async function validateQueryParams(queryParams) {
 }
 
 function getSortingPropertyForQuery(sort?: string) {
-  if (!sort) {
-    return null;
-  }
+  sort = sort ? sort : 'is-bestuurlijke-alias-van.achternaam';
 
   const mapping = {
     'is-bestuurlijke-alias-van.gebruikte-voornaam': '?fName',

--- a/data-access/mandataris-download.ts
+++ b/data-access/mandataris-download.ts
@@ -31,24 +31,13 @@ async function getUrisForFilters(filters) {
     `;
   }
   if (filters.activeOnly) {
-    const escapedTodaysDate = sparqlEscapeDateTime(new Date());
-    // the str() call is necessary because otherwise the comparison fails in virtuoso (datatype issue?)
     onlyActiveFilter = `
       OPTIONAL {
         ?mandataris mandaat:einde ?einde.
       }
-      ?bestuursorgaanInTijd mandaat:bindingStart ?startBestuursorgaan.
-      OPTIONAL {
-        ?bestuursorgaanInTijd mandaat:bindingEinde ?eindeBestuursorgaan.
-      }
-
-      BIND(IF(BOUND(?eindeBestuursorgaan), ?eindeBestuursorgaan, ${escapedTodaysDate}) AS ?safeEindeBestuursorgaan).
-      BIND(IF(BOUND(?einde), ?einde, ${escapedTodaysDate}) AS ?safeEinde).
-      FILTER (
-        STR(?safeEinde) <= STR(?safeEindeBestuursorgaan) &&
-        STR(?safeEinde) >= STR(?startBestuursorgaan) &&
-        STR(?safeEinde) >= STR(${escapedTodaysDate})
-      )
+      BIND(IF(BOUND(?einde), ?einde, "3000-01-01"^^xsd:dateTime) AS ?safeEinde)
+      BIND(NOW() AS ?now)
+      FILTER (?now <= ?safeEinde)
     `;
   }
 


### PR DESCRIPTION
## Description

There were some issues with the export for mandatarissen in Roeselare. 
Seems that the activeFilter did not really work correctly, simplified it to make it more in line with the fronted.
Also fixed the sorting, some issues there as well.

## How to test

Try exporting some mandatarissen in different places with diferent settings, and look if it is what you expect to get. Certainly check the export for BCSD Roeselare that this export is not empty.

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/180
