### PR TITLE
LMB-1440 fix missing prefix

### DIFF
--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -929,6 +929,7 @@ async function bulkUpdateEndDate(mandatarisUris: Array<string>, endDate: Date) {
   };
   const updateQuery = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+    PREFIX dct: <http://purl.org/dc/terms/>
 
     DELETE {
       ?mandataris mandaat:einde ?endDate.


### PR DESCRIPTION
## Description

End active mandatees was broken, this should fix it.

## How to test

Try ending all mandatees linked to a person with the "beeindig" button. 
