### PR TITLE
lmb-1428 | Notification for mandataris that is more than 10 days active

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -11,10 +11,11 @@ import { burgemeesterRouter } from './routes/burgemeester-benoeming';
 import { installatievergaderingRouter } from './routes/installatievergadering';
 import { organenRouter } from './routes/organen';
 import { mockRouter } from './routes/mock';
-
-import { cronjob as harvestBekrachtigingenCron } from './cron/fetch-bekrachtigingen';
 import { electionResultsRouter } from './routes/verkiezingsresultaten';
 import { rangordeRouter } from './routes/rangorde';
+
+import { cronjob as harvestBekrachtigingenCron } from './cron/fetch-bekrachtigingen';
+import { cronjob as notificationActiveMandateesWithoutBesluitCron } from './cron/notification-for-bekrachtigde-mandataris';
 
 app.use(
   bodyParser.json({
@@ -52,7 +53,6 @@ const errorHandler: ErrorRequestHandler = function (err, _req, res, _next) {
 
 app.use(errorHandler);
 
-//FIXME disable notifications for now
-//notificationBekrachtigdMandataris.start();
+notificationActiveMandateesWithoutBesluitCron.start();
 // FIXME disabled handling of decision queue because the publications are broken right now. Reactivate when we have decent publications again
 harvestBekrachtigingenCron.start();

--- a/app.ts
+++ b/app.ts
@@ -14,7 +14,6 @@ import { mockRouter } from './routes/mock';
 import { electionResultsRouter } from './routes/verkiezingsresultaten';
 import { rangordeRouter } from './routes/rangorde';
 
-import { cronjob as harvestBekrachtigingenCron } from './cron/fetch-bekrachtigingen';
 import { cronjob as notificationActiveMandateesWithoutBesluitCron } from './cron/notification-for-bekrachtigde-mandataris';
 
 app.use(
@@ -54,5 +53,3 @@ const errorHandler: ErrorRequestHandler = function (err, _req, res, _next) {
 app.use(errorHandler);
 
 notificationActiveMandateesWithoutBesluitCron.start();
-// FIXME disabled handling of decision queue because the publications are broken right now. Reactivate when we have decent publications again
-harvestBekrachtigingenCron.start();

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -101,6 +101,7 @@ async function getContactEmailForMandataris(mandatarisUri?: string) {
 }
 
 async function fetchEffectiveMandatarissenWithoutBesluitAndNotification() {
+  // TODO: fix this method so it gets active mandatarissen after 10 days
   const momentTenDaysAgo = moment(new Date()).subtract(10, 'days');
   const escapedTenDaysBefore = sparqlEscapeDateTime(momentTenDaysAgo.toDate());
   const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
@@ -124,9 +125,6 @@ async function fetchEffectiveMandatarissenWithoutBesluitAndNotification() {
             org:holds / org:role ?bestuursfunctie .
           ?person persoon:gebruikteVoornaam ?fName ;
             foaf:familyName ?lName .
-          OPTIONAL {
-            ?mandataris lmb:effectiefAt ?effectiefAt .
-          }
 
           FILTER NOT EXISTS {
             ?notification a ext:SystemNotification;
@@ -140,9 +138,6 @@ async function fetchEffectiveMandatarissenWithoutBesluitAndNotification() {
         FILTER NOT EXISTS {
           ?graph a <http://mu.semte.ch/graphs/public>
         }
-
-        BIND(IF(BOUND(?effectiefAt), ?effectiefAt, ${escapedTenDaysBefore}) AS ?saveEffectiefAt).
-        FILTER(${escapedTenDaysBefore} >= ?saveEffectiefAt)
       }
       ORDER BY ?bestuursfunctieName ?lName
   `;

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -198,6 +198,7 @@ async function fetchActiveMandatarissenWithoutBesluit() {
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
     SELECT DISTINCT ?mandataris ?fName ?lName ?bestuursfunctieName ?graph
       WHERE {
@@ -206,18 +207,21 @@ async function fetchActiveMandatarissenWithoutBesluit() {
             lmb:hasPublicationStatus ${nietBekrachtigd} ;
             mandaat:start ?startMandaat ;
             mandaat:isBestuurlijkeAliasVan ?person ;
-            org:holds / org:role ?bestuursfunctie .
+            org:holds ?mandaat.
+          ?mandaat org:role ?bestuursfunctie .
+          ?orgT org:hasPost ?mandaat .
+          ?orgT mandaat:isTijdspecialisatieVan / besluit:bestuurt ?eenheid .
           ?person persoon:gebruikteVoornaam ?fName ;
             foaf:familyName ?lName .
           VALUES ?bestuursfunctie {
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011>
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014>
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000019>
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000012>
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001a>
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38>
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a>
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013>
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011> # Gemeenteraadslid
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014> # Schepen
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000019> # Lid van het Bijzonder Comité voor de Sociale Dienst
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000012> # Voorzitter van de gemeenteraad
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001a> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38> # Toegevoegde schepen
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a> # Aangewezen burgemeester
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013> # Burgemeester
           }
 
           FILTER NOT EXISTS {
@@ -258,3 +262,5 @@ async function fetchActiveMandatarissenWithoutBesluit() {
     );
   }
 }
+
+setTimeout(() => handleMandatarissen(), 10000);

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -106,10 +106,10 @@ async function getContactEmailForMandataris(mandatarisUri?: string) {
 }
 
 async function fetchActiveMandatarissenWithoutBesluit() {
-  const momentTenDaysAgo = moment(new Date()).subtract(10, 'days');
+  const momentTenDaysAgo = moment().subtract(10, 'days');
   const escapedTenDaysBefore = sparqlEscapeDateTime(momentTenDaysAgo.toDate());
   const nietBekrachtigd = sparqlEscapeUri(PUBLICATION_STATUS.NIET_BEKRACHTIGD);
-  const today = sparqlEscapeDateTime(moment(new Date()).toDate());
+  const today = sparqlEscapeDateTime(moment().toDate());
   const query = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX dct: <http://purl.org/dc/terms/>

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -201,6 +201,16 @@ async function fetchActiveMandatarissenWithoutBesluit() {
             org:holds / org:role ?bestuursfunctie .
           ?person persoon:gebruikteVoornaam ?fName ;
             foaf:familyName ?lName .
+          VALUES ?bestuursfunctie {
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011>
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014>
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000019>
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000012>
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001a>
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38>
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a>
+            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013>
+          }
 
           FILTER NOT EXISTS {
             ?notification a ext:SystemNotification;
@@ -240,3 +250,4 @@ async function fetchActiveMandatarissenWithoutBesluit() {
     );
   }
 }
+setTimeout(() => handleMandatarissen(), 10000);

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -2,6 +2,7 @@ import { CronJob } from 'cron';
 
 import moment from 'moment';
 import { querySudo } from '@lblod/mu-auth-sudo';
+import { sparqlEscapeDateTime, sparqlEscapeString, sparqlEscapeUri } from 'mu';
 
 import { findFirstSparqlResult, getSparqlResults } from '../util/sparql-result';
 import { PUBLICATION_STATUS } from '../util/constants';
@@ -11,7 +12,6 @@ import {
   SEND_EMAILS,
   sendMissingBekrachtigingsmail,
 } from '../util/create-email';
-import { sparqlEscapeDateTime, sparqlEscapeString, sparqlEscapeUri } from 'mu';
 
 const SUBJECT = 'Actieve mandatarissen zonder besluit';
 const NOTIFICATION_CRON_PATTERN =

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -262,5 +262,3 @@ async function fetchActiveMandatarissenWithoutBesluit() {
     );
   }
 }
-
-setTimeout(() => handleMandatarissen(), 10000);

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -94,9 +94,15 @@ async function getContactEmailForMandataris(mandatarisUri?: string) {
 
     } LIMIT 1
   `;
-  const sparqlResult = await querySudo(query);
+  try {
+    const sparqlResult = await querySudo(query);
 
-  return findFirstSparqlResult(sparqlResult)?.email?.value;
+    return findFirstSparqlResult(sparqlResult)?.email?.value;
+  } catch (error) {
+    throw new HttpError(
+      'Something went wrong while trying to get the contact email for the mandataris.',
+    );
+  }
 }
 
 async function fetchActiveMandatarissenWithoutBesluit() {

--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -13,7 +13,7 @@ import {
   sendMissingBekrachtigingsmail,
 } from '../util/create-email';
 
-const SUBJECT = 'Actieve mandatarissen zonder besluit';
+export const SUBJECT_DECISION = 'Actieve mandatarissen zonder besluit';
 const NOTIFICATION_CRON_PATTERN =
   process.env.NOTIFICATION_CRON_PATTERN || '0 8 * * 1-5'; // Every weekday at 8am
 console.log(`NOTIFICATION CRON TIME SET TO: ${NOTIFICATION_CRON_PATTERN}`);
@@ -42,7 +42,7 @@ export async function handleMandatarissen() {
   }
 
   await createBulkNotificationMandatarissenWithoutBesluit(
-    SUBJECT,
+    SUBJECT_DECISION,
     mandatarissen,
   );
   if (SEND_EMAILS) {
@@ -134,7 +134,7 @@ async function fetchActiveMandatarissenWithoutBesluit() {
 
           FILTER NOT EXISTS {
             ?notification a ext:SystemNotification;
-              dct:subject ${sparqlEscapeString(SUBJECT)};
+              dct:subject ${sparqlEscapeString(SUBJECT_DECISION)};
               ext:notificationLink ?notificationLink.
             ?notificationLink ext:linkedTo ?mandataris.
           }

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -602,13 +602,11 @@ export async function bulkSetPublicationStatusNietBekrachtigd(
     DELETE {
       GRAPH ?graph {
         ?mandataris lmb:hasPublicationStatus ?status .
-        ?mandataris lmb:effectiefAt ?effectiefAt .
       }
     }
     INSERT {
       GRAPH ?graph {
         ?mandataris lmb:hasPublicationStatus ${escaped.nietBekrachtigd} .
-        ?mandataris lmb:effectiefAt ${escaped.todaysDate} .
       }
     }
     WHERE {
@@ -617,9 +615,6 @@ export async function bulkSetPublicationStatusNietBekrachtigd(
           mu:uuid ?uuid .
         OPTIONAL {
           ?mandataris lmb:hasPublicationStatus ?status .
-        }
-        OPTIONAL {
-          ?mandataris lmb:effectiefAt ?effectiefAt .
         }
         VALUES ?uuid { ${escaped.mandatarissenUuids} }
         FILTER (!BOUND(?status) || ?status NOT IN (${escaped.bekrachtigd}))

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -10,6 +10,7 @@ services:
       NO_BABEL_NODE: true
       EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: email@address.com
       SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
+      NOTIFICATION_CRON_PATTERN: '0 0 0 * * *'
     ports:
       - '8082:80'
       - '9225:9229'

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -9,7 +9,6 @@ services:
       NODE_ENV: development
       NO_BABEL_NODE: true
       EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: email@address.com
-      NOTIFICATION_CRON_PATTERN: '*/2 * * * *' # Every 2 minutes
       SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
     ports:
       - '8082:80'
@@ -18,7 +17,6 @@ services:
       - ../app-lokaal-mandatenbeheer/config/mandataris:/config
       - ../app-lokaal-mandatenbeheer/data/files/burgemeester-benoemingen:/uploads
       - ./:/app
-
     networks:
       - debug
 

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -8,8 +8,9 @@ services:
     environment:
       NODE_ENV: development
       NO_BABEL_NODE: true
-      EMAIL_FROM_MANDATARIS_EFFECTIEF: email@address.com
-      SEND_EMAIL_FOR_MANDATARIS_EFFECTIEF: false
+      EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: email@address.com
+      NOTIFICATION_CRON_PATTERN: '*/2 * * * *' # Every 2 minutes
+      SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
     ports:
       - '8082:80'
       - '9225:9229'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mandataris-service",
   "version": "0.0.3",
+  "type": "module",
   "description": "Service to handle backend business logic for mandataris instances",
   "main": "app.js",
   "author": "redpencil.io",

--- a/routes/installatievergadering.ts
+++ b/routes/installatievergadering.ts
@@ -442,14 +442,12 @@ async function setMandatarissenToNietBekrachtigd(installatievergaderingId) {
   DELETE {
     GRAPH ?target {
       ?mandataris lmb:hasPublicationStatus ?old.
-      ?mandataris lmb:effectiefAt ?oldDate.
       ?mandataris dct:modified ?oldMod.
     }
   }
   INSERT {
     GRAPH ?target {
       ?mandataris lmb:hasPublicationStatus ${nietBekrachtigd} .
-      ?mandataris lmb:effectiefAt ?now.
       ?mandataris dct:modified ?now.
     }
   } WHERE {
@@ -473,9 +471,6 @@ async function setMandatarissenToNietBekrachtigd(installatievergaderingId) {
 
       OPTIONAL {
         ?mandataris lmb:hasPublicationStatus ?old.
-      }
-      OPTIONAL {
-        ?mandataris lmb:effectiefAt ?oldDate.
       }
       OPTIONAL {
         ?mandataris dct:modified ?oldMod.

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -5,7 +5,9 @@ import { updateSudo } from '@lblod/mu-auth-sudo';
 const EMAIL_FROM_MANDATARIS_WITHOUT_DECISION =
   process.env.EMAIL_FROM_MANDATARIS_WITHOUT_DECISION;
 export const SEND_EMAILS =
-  process.env.SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION ?? false;
+  process.env.SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION === 'true'
+    ? true
+    : false;
 
 if (SEND_EMAILS && !EMAIL_FROM_MANDATARIS_WITHOUT_DECISION) {
   throw 'Please set the email adres to the value set in the LMB app EMAIL_FROM_MANDATARIS_WITHOUT_DECISION must equal to EMAIL_ADDRESS';

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -3,7 +3,8 @@ import { sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
 import { updateSudo } from '@lblod/mu-auth-sudo';
 
 import { HttpError } from './http-error';
-import { SUBJECT_DECISION } from '../cron/notification-for-bekrachtigde-mandataris';
+
+const SUBJECT_DECISION = 'Actieve mandatarissen zonder besluit';
 
 const EMAIL_FROM_MANDATARIS_WITHOUT_DECISION =
   process.env.EMAIL_FROM_MANDATARIS_WITHOUT_DECISION;

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -2,21 +2,20 @@ import { v4 as uuid } from 'uuid';
 import { sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
 import { updateSudo } from '@lblod/mu-auth-sudo';
 
-// These notifications/emails are not sent atm
-// A ticket was created to update this logic
-// TODO: update all effectief to be Niet bekrachtigd
-const EMAIL_FROM_MANDATARIS_EFFECTIEF =
-  process.env.EMAIL_FROM_MANDATARIS_EFFECTIEF;
+const EMAIL_FROM_MANDATARIS_WITHOUT_DECISION =
+  process.env.EMAIL_FROM_MANDATARIS_WITHOUT_DECISION;
 export const SEND_EMAILS =
-  process.env.SEND_EMAIL_FOR_MANDATARIS_EFFECTIEF ?? false;
+  process.env.SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION ?? false;
 
-if (SEND_EMAILS && !EMAIL_FROM_MANDATARIS_EFFECTIEF) {
-  throw 'Please set the email adres to the value set in the LMB app EMAIL_FROM_MANDATARIS_EFFECTIEF must equal to EMAIL_ADDRESS';
+if (SEND_EMAILS && !EMAIL_FROM_MANDATARIS_WITHOUT_DECISION) {
+  throw 'Please set the email adres to the value set in the LMB app EMAIL_FROM_MANDATARIS_WITHOUT_DECISION must equal to EMAIL_ADDRESS';
 }
 console.log(
-  `EMAIL_FROM_MANDATARIS_EFFECTIEF SET TO: ${EMAIL_FROM_MANDATARIS_EFFECTIEF}`,
+  `EMAIL_FROM_MANDATARIS_WITHOUT_DECISION SET TO: ${EMAIL_FROM_MANDATARIS_WITHOUT_DECISION}`,
 );
-console.log(`SEND_EMAIL_FOR_MANDATARIS_EFFECTIEF SET TO: ${SEND_EMAILS}`);
+console.log(
+  `SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION SET TO: ${SEND_EMAILS}`,
+);
 
 export async function sendMissingBekrachtigingsmail(
   emailTo: string,
@@ -34,11 +33,13 @@ export async function sendMissingBekrachtigingsmail(
       </tr>
     `;
   }
-  const from = sparqlEscapeString(EMAIL_FROM_MANDATARIS_EFFECTIEF as string);
+  const from = sparqlEscapeString(
+    EMAIL_FROM_MANDATARIS_WITHOUT_DECISION as string,
+  );
   const to = sparqlEscapeString(emailTo);
   const htmlMessage = `
     <p>Beste,</p>
-    <p>Er zijn een aantal mandatarissen die al meer dan 10 dagen de publicatiestatus ‘Niet bekrachtigd’ hebben zonder koppeling met een besluit. Voor uw gemeente zijn dit er ${mandatarissen.length}.</p>
+    <p>Er zijn een aantal mandatarissen die al meer dan 10 dagen actief zijn zonder dat er een koppeling met een besluit is gemaakt. Voor uw gemeente zijn dit er ${mandatarissen.length}.</p>
     <p> Hieronder vindt u een overzicht van al deze mandatarissen: <p>
     <table>
       <tr>

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -3,6 +3,7 @@ import { sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
 import { updateSudo } from '@lblod/mu-auth-sudo';
 
 import { HttpError } from './http-error';
+import { SUBJECT_DECISION } from '../cron/notification-for-bekrachtigde-mandataris';
 
 const EMAIL_FROM_MANDATARIS_WITHOUT_DECISION =
   process.env.EMAIL_FROM_MANDATARIS_WITHOUT_DECISION;
@@ -68,7 +69,7 @@ export async function sendMissingBekrachtigingsmail(
       <http://data.lblod.info/id/emails/${uuid()}> a nmo:Email;
         nmo:messageFrom ${from};
         nmo:emailTo ${to};
-        nmo:messageSubject "Besluit voor mandataris";
+        nmo:messageSubject ${sparqlEscapeString(SUBJECT_DECISION)};
         nmo:htmlMessageContent ${sparqlEscapeString(htmlMessage)} ;
         nmo:sentDate ${sparqlEscapeDateTime(new Date())};
         nmo:isPartOf <http://data.lblod.info/id/mail-folders/2>.

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -2,6 +2,8 @@ import { v4 as uuid } from 'uuid';
 import { sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
 import { updateSudo } from '@lblod/mu-auth-sudo';
 
+import { HttpError } from './http-error';
+
 const EMAIL_FROM_MANDATARIS_WITHOUT_DECISION =
   process.env.EMAIL_FROM_MANDATARIS_WITHOUT_DECISION;
 export const SEND_EMAILS =
@@ -76,8 +78,8 @@ export async function sendMissingBekrachtigingsmail(
   try {
     await updateSudo(insertQuery);
   } catch (error) {
-    console.log(
-      `Something went wrong when sending an email to ${to} for mandataris in effectief status without decision..`,
+    throw new HttpError(
+      `Something went wrong while creating the email to ${to} for active mandatarissen without decision.`,
     );
   }
 }

--- a/util/create-notification.ts
+++ b/util/create-notification.ts
@@ -117,6 +117,7 @@ export async function getMandatarisNotificationGraph(mandataris: string) {
 export async function createBulkNotificationMandatarissenWithoutBesluit(
   title: string,
   mandatarissen,
+  key: string,
 ) {
   const data = mandatarissen
     .map((mandataris) => {
@@ -137,6 +138,7 @@ export async function createBulkNotificationMandatarissenWithoutBesluit(
             dct:subject ${sparqlEscapeString(title)} ;
             schema:description ${sparqlEscapeString(description)} ;
             dct:created ${sparqlEscapeDateTime(new Date())} ;
+            ext:generatedByRun ${sparqlEscapeString(key)} ;
             dct:type ${sparqlEscapeUri(notificationTypes['warning'])} ;
             ext:notificationLink ${link} .
           ${link} a ext:SystemNotificationLink ;

--- a/util/create-notification.ts
+++ b/util/create-notification.ts
@@ -128,7 +128,7 @@ export async function createBulkNotificationMandatarissenWithoutBesluit(
       const link = sparqlEscapeUri(
         `http://data.lblod.info/id/SystemNotificationLink/${linkId}`,
       );
-      const description = `De publicatie status van ${mandataris.name} met mandaat ${mandataris.mandate} staat al 10 dagen of meer op effectief zonder dat er een besluit is toegevoegd. Gelieve deze mandataris manueel te bekrachtigen en een besluit toe te voegen of publiceer het besluit van de installatievergadering via een notuleringspakket.`;
+      const description = `De mandataris van ${mandataris.name} met mandaat ${mandataris.mandate} is al 10 dagen actief zonder dat er een besluit is toegevoegd. Gelieve deze mandataris manueel te bekrachtigen en een besluit toe te voegen of publiceer het besluit van de installatievergadering via een notuleringspakket.`;
 
       return `
         GRAPH ${sparqlEscapeUri(mandataris.graph)} {

--- a/util/http-error.ts
+++ b/util/http-error.ts
@@ -1,9 +1,19 @@
+import { STATUS_CODE } from './constants';
+
 export class HttpError extends Error {
   constructor(
     message: string,
-    public status: number,
-    public description: string[] | null = null,
+    public status?: number,
+    public description?: string[],
   ) {
     super(message);
+
+    if (!this.status) {
+      this.status = STATUS_CODE.INTERNAL_SERVER_ERROR;
+    }
+    if (!this.description) {
+      this.description = null;
+    }
+    console.log('\n Http error: ', this.message);
   }
 }


### PR DESCRIPTION
## Description

We want to change the logic for notifications. Before 10 days after effectief (niet-bekrachtigd publication status) a notification was send (this was disabled). We do want these notifications but when a mandataris is active for more than 10 days. (start date + 10 days  > today)

## How to test

- Create a mandataris with start date 10 days past today, a notification should be create when the cron is executed

## Links to other PR's

- [frontend](https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/515)
- [app](https://github.com/lblod/app-lokaal-mandatenbeheer/pull/398)
