### PR TITLE
don't mail for mayor, mail in plain text to avoid spam

### DIFF
--- a/cron/notification-for-bekrachtigde-mandataris.ts
+++ b/cron/notification-for-bekrachtigde-mandataris.ts
@@ -221,7 +221,6 @@ async function fetchActiveMandatarissenWithoutBesluit() {
             <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001a> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
             <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38> # Toegevoegde schepen
             <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a> # Aangewezen burgemeester
-            <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013> # Burgemeester
           }
 
           FILTER NOT EXISTS {

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -8,7 +8,7 @@ services:
     environment:
       NODE_ENV: development
       NO_BABEL_NODE: true
-      EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: email@address.com
+      EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: 'lokaalmandatenbeheer@vlaanderen.be'
       SEND_EMAIL_FOR_MANDATARIS_WITHOUT_DECISION: false
       NOTIFICATION_CRON_PATTERN: '0 0 0 * * *'
     ports:

--- a/util/create-email.ts
+++ b/util/create-email.ts
@@ -30,35 +30,30 @@ export async function sendMissingBekrachtigingsmail(
   if (mandatarissen.length === 0) {
     return;
   }
-  let mandatarisRows = '';
+  const mandatarisRows = [];
   for (const mandataris of mandatarissen) {
-    mandatarisRows += `
-      <tr>
-        <td style="padding: 8px">${mandataris.name}</td>
-        <td style="padding: 8px">${mandataris.mandate}</td>
-      </tr>
-    `;
+    mandatarisRows.push(`${mandataris.name} (${mandataris.mandate})`);
   }
   const from = sparqlEscapeString(
     EMAIL_FROM_MANDATARIS_WITHOUT_DECISION as string,
   );
   const to = sparqlEscapeString(emailTo);
-  const htmlMessage = `
-    <p>Beste,</p>
-    <p>Er zijn een aantal mandatarissen die al meer dan 10 dagen actief zijn zonder dat er een koppeling met een besluit is gemaakt. Voor uw gemeente zijn dit er ${mandatarissen.length}.</p>
-    <p> Hieronder vindt u een overzicht van al deze mandatarissen: <p>
-    <table>
-      <tr>
-        <th style="text-align:left;padding:8px">Naam</th>
-        <th style="text-align:left;padding:8px">Mandaat</th>
-      </tr>
-      ${mandatarisRows}
-    </table>
-    <p>Gelieve het besluit te koppelen.</p>
-    <br/>
-    <p>Met vriendelijke groeten,</p>
-    <p>Agentschap Binnenlands Bestuur</p>
-  `;
+  const plainTextMessage = `
+Beste,
+
+Er zijn een aantal mandatarissen die al meer dan 10 dagen actief zijn zonder dat er een koppeling met een besluit is gemaakt.
+Voor uw gemeente zijn dit er ${mandatarissen.length}.
+
+Hieronder vindt u een overzicht van al deze mandatarissen:
+
+${mandatarisRows.join('\n')}
+
+Gelieve het besluit te koppelen.
+
+Met vriendelijke groeten,
+
+Agentschap Binnenlands Bestuur
+`;
 
   const insertQuery = `
   PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
@@ -71,7 +66,7 @@ export async function sendMissingBekrachtigingsmail(
         nmo:messageFrom ${from};
         nmo:emailTo ${to};
         nmo:messageSubject ${sparqlEscapeString(SUBJECT_DECISION)};
-        nmo:htmlMessageContent ${sparqlEscapeString(htmlMessage)} ;
+        nmo:plainTextMessageContent ${sparqlEscapeString(plainTextMessage)} ;
         nmo:sentDate ${sparqlEscapeDateTime(new Date())};
         nmo:isPartOf <http://data.lblod.info/id/mail-folders/2>.
     }


### PR DESCRIPTION
## Description

don't mail for mayor, mail in plain text to avoid spam
## How to test

have the cron job run (tweak the cron config and enable sending mails)
check the mails in the db, notice that they are now plain text instead of html

```
  PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
  SELECT ?g ?s ?p ?o WHERE {
    graph ?g {
    ?s a <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#Email>.
    ?s ?p ?o.
      }
```
Notice that we're not mailing for mayors.

