### PR TITLE
lmb-1673: update the idempotent PUT calls to be POST calls

### DIFF
--- a/routes/fractie.ts
+++ b/routes/fractie.ts
@@ -50,7 +50,7 @@ fractiesRouter.get(
   },
 );
 
-fractiesRouter.put(
+fractiesRouter.post(
   '/:mandatarisId/current-fractie',
   async (req: Request, res: Response) => {
     const id = req.params.mandatarisId;

--- a/routes/mandatarissen.ts
+++ b/routes/mandatarissen.ts
@@ -96,7 +96,7 @@ mandatarissenRouter.post(
   },
 );
 
-mandatarissenRouter.put(
+mandatarissenRouter.post(
   '/:id/correct-linked-mandataris',
   async (req: Request, res: Response) => {
     try {
@@ -112,7 +112,7 @@ mandatarissenRouter.put(
   },
 );
 
-mandatarissenRouter.put(
+mandatarissenRouter.post(
   '/:oldId/:newId/update-state-linked-mandataris',
   async (req: Request, res: Response) => {
     try {
@@ -128,7 +128,7 @@ mandatarissenRouter.put(
   },
 );
 
-mandatarissenRouter.put(
+mandatarissenRouter.post(
   '/:id/add-linked-replacement',
   async (req: Request, res: Response) => {
     try {


### PR DESCRIPTION
## Description

Find the idempotent PUT calls and udpate them to be POST

## How to test

1. search for .put and have a look if there are endpoints i missed that are also idempotent
2. All functionality should still work with the frontend

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/595
