### PR TITLE
LMB-1695 | Allow renaming fractions

### DIFF
--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -54,4 +54,21 @@ async function removeFractieWhenNoLidmaatschap(
 async function createReplacement(
   currentFractieId: string,
   bestuursperiodeId: string,
-): Promise<void> {}
+): Promise<void> {
+  const isBestuursperiode = await areIdsValid(RDF_TYPE.BESTUURSPERIODE, [
+    bestuursperiodeId,
+  ]);
+  if (!isBestuursperiode) {
+    throw new HttpError(
+      `Bestuursperiode with id ${bestuursperiodeId} not found.`,
+      STATUS_CODE.BAD_REQUEST,
+    );
+  }
+  const isFractie = await areIdsValid(RDF_TYPE.FRACTIE, [currentFractieId]);
+  if (!isFractie) {
+    throw new HttpError(
+      `Fractie with id ${currentFractieId} not found.`,
+      STATUS_CODE.BAD_REQUEST,
+    );
+  }
+}

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -6,6 +6,7 @@ import { HttpError } from '../util/http-error';
 export const fractieUsecase = {
   forBestuursperiode,
   removeFractieWhenNoLidmaatschap,
+  createReplacement,
 };
 
 async function forBestuursperiode(
@@ -49,3 +50,8 @@ async function removeFractieWhenNoLidmaatschap(
 
   return await fractie.removeFractieWhenNoLidmaatschap(bestuursperiodeId);
 }
+
+async function createReplacement(
+  currentFractieId: string,
+  bestuursperiodeId: string,
+): Promise<void> {}

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -53,18 +53,8 @@ async function removeFractieWhenNoLidmaatschap(
 
 async function createReplacement(
   currentFractieId: string,
-  bestuursperiodeId: string,
   fractieLabel?: string,
 ): Promise<void> {
-  const isBestuursperiode = await areIdsValid(RDF_TYPE.BESTUURSPERIODE, [
-    bestuursperiodeId,
-  ]);
-  if (!isBestuursperiode) {
-    throw new HttpError(
-      `Bestuursperiode with id ${bestuursperiodeId} not found.`,
-      STATUS_CODE.BAD_REQUEST,
-    );
-  }
   const isFractie = await areIdsValid(RDF_TYPE.FRACTIE, [currentFractieId]);
   if (!isFractie) {
     throw new HttpError(
@@ -78,9 +68,5 @@ async function createReplacement(
       STATUS_CODE.BAD_REQUEST,
     );
   }
-  await fractie.replaceFractie(
-    currentFractieId,
-    bestuursperiodeId,
-    fractieLabel,
-  );
+  await fractie.replaceFractie(currentFractieId, fractieLabel);
 }

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -54,6 +54,7 @@ async function removeFractieWhenNoLidmaatschap(
 async function createReplacement(
   currentFractieId: string,
   bestuursperiodeId: string,
+  fractieLabel?: string,
 ): Promise<void> {
   const isBestuursperiode = await areIdsValid(RDF_TYPE.BESTUURSPERIODE, [
     bestuursperiodeId,
@@ -71,4 +72,15 @@ async function createReplacement(
       STATUS_CODE.BAD_REQUEST,
     );
   }
+  if (!fractieLabel || fractieLabel?.trim() === '') {
+    throw new HttpError(
+      'Replacement fractie label cannot be empty',
+      STATUS_CODE.BAD_REQUEST,
+    );
+  }
+  await fractie.replaceFractie(
+    currentFractieId,
+    bestuursperiodeId,
+    fractieLabel,
+  );
 }

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -61,19 +61,16 @@ async function createReplacement(
   const isFractie = await areIdsValid(RDF_TYPE.FRACTIE, [currentFractieId]);
   if (!isFractie) {
     throw new HttpError(
-      `Fractie with id ${currentFractieId} not found.`,
+      `Fractie met id ${currentFractieId} werd niet gevonden`,
       STATUS_CODE.BAD_REQUEST,
     );
   }
   if (!fractieLabel || fractieLabel?.trim() === '') {
-    throw new HttpError(
-      'Replacement fractie label cannot be empty',
-      STATUS_CODE.BAD_REQUEST,
-    );
+    throw new HttpError('Fractie label is verplicht.', STATUS_CODE.BAD_REQUEST);
   }
   if (!endDate) {
     throw new HttpError(
-      'An endDate is required but not found.',
+      'Een start datum voor de nieuwe fractie is verplicht.',
       STATUS_CODE.BAD_REQUEST,
     );
   }
@@ -81,7 +78,7 @@ async function createReplacement(
   const canReplaceFractie = await fractie.canReplaceFractie(currentFractieId);
   if (!canReplaceFractie) {
     throw new HttpError(
-      'Fractions that have ended cannot be replaced.',
+      'Deze fractie kan niet meer aangepast worden.',
       STATUS_CODE.BAD_REQUEST,
     );
   }
@@ -92,7 +89,7 @@ async function createReplacement(
     );
   if (!hasEndDateAfterCurrent) {
     throw new HttpError(
-      'Fraction date must be after previous fraction.',
+      'Fractie startdatum ligt voor de einddatum van de huidige fractie',
       STATUS_CODE.BAD_REQUEST,
     );
   }

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -81,13 +81,19 @@ async function createReplacement(
   const canReplaceFractie = await fractie.canReplaceFractie(currentFractieId);
   if (!canReplaceFractie) {
     throw new HttpError(
-      'Fractions that have or are a replacement cannot be replaced.',
+      'Fractions that have ended cannot be replaced.',
       STATUS_CODE.BAD_REQUEST,
     );
   }
 
-  await fractie.replaceFractie(currentFractieId, fractieLabel, endDate);
-  const mandatarisUrisForCurrentFractie =
-    await mandataris.getMandatarissenForFractie(currentFractieId);
-  await mandataris.bulkUpdateEndDate(mandatarisUrisForCurrentFractie, endDate);
+  const replacementUri = await fractie.replaceFractie(
+    currentFractieId,
+    fractieLabel,
+    endDate,
+  );
+  await mandataris.createNewMandatarissenForFractieReplacement(
+    currentFractieId,
+    replacementUri,
+    endDate,
+  );
 }

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -89,9 +89,5 @@ async function createReplacement(
   await fractie.replaceFractie(currentFractieId, fractieLabel, endDate);
   const mandatarisUrisForCurrentFractie =
     await mandataris.getMandatarissenForFractie(currentFractieId);
-  await mandataris.bulkUpdateEndDate(
-    mandatarisUrisForCurrentFractie,
-    endDate,
-    true,
-  );
+  await mandataris.bulkUpdateEndDate(mandatarisUrisForCurrentFractie, endDate);
 }

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -76,9 +76,8 @@ async function createReplacement(
     );
   }
 
-  const isCurrentAlreadyAReplacement =
-    await fractie.isOrHasReplacement(currentFractieId);
-  if (isCurrentAlreadyAReplacement) {
+  const canReplaceFractie = await fractie.canReplaceFractie(currentFractieId);
+  if (!canReplaceFractie) {
     throw new HttpError(
       'Fractions that have or are a replacement cannot be replaced.',
       STATUS_CODE.BAD_REQUEST,

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -54,6 +54,7 @@ async function removeFractieWhenNoLidmaatschap(
 async function createReplacement(
   currentFractieId: string,
   fractieLabel?: string,
+  endDate?: Date,
 ): Promise<void> {
   const isFractie = await areIdsValid(RDF_TYPE.FRACTIE, [currentFractieId]);
   if (!isFractie) {
@@ -68,6 +69,12 @@ async function createReplacement(
       STATUS_CODE.BAD_REQUEST,
     );
   }
+  if (!endDate) {
+    throw new HttpError(
+      'An endDate is required but not found.',
+      STATUS_CODE.BAD_REQUEST,
+    );
+  }
 
   const isCurrentAlreadyAReplacement =
     await fractie.isOrHasReplacement(currentFractieId);
@@ -78,5 +85,5 @@ async function createReplacement(
     );
   }
 
-  await fractie.replaceFractie(currentFractieId, fractieLabel);
+  await fractie.replaceFractie(currentFractieId, fractieLabel, endDate);
 }

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -68,5 +68,15 @@ async function createReplacement(
       STATUS_CODE.BAD_REQUEST,
     );
   }
+
+  const isCurrentAlreadyAReplacement =
+    await fractie.isOrHasReplacement(currentFractieId);
+  if (isCurrentAlreadyAReplacement) {
+    throw new HttpError(
+      'Fractions that have or are a replacement cannot be replaced.',
+      STATUS_CODE.BAD_REQUEST,
+    );
+  }
+
   await fractie.replaceFractie(currentFractieId, fractieLabel);
 }

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -1,4 +1,6 @@
 import { fractie } from '../data-access/fractie';
+import { mandataris } from '../data-access/mandataris';
+
 import { areIdsValid, RDF_TYPE } from '../util/valid-id';
 import { STATUS_CODE } from '../util/constants';
 import { HttpError } from '../util/http-error';
@@ -85,4 +87,11 @@ async function createReplacement(
   }
 
   await fractie.replaceFractie(currentFractieId, fractieLabel, endDate);
+  const mandatarisUrisForCurrentFractie =
+    await mandataris.getMandatarissenForFractie(currentFractieId);
+  await mandataris.bulkUpdateEndDate(
+    mandatarisUrisForCurrentFractie,
+    endDate,
+    true,
+  );
 }

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -85,6 +85,17 @@ async function createReplacement(
       STATUS_CODE.BAD_REQUEST,
     );
   }
+  const hasEndDateAfterCurrent =
+    await fractie.isReplacementStartDateAfterCurrentStart(
+      currentFractieId,
+      endDate,
+    );
+  if (!hasEndDateAfterCurrent) {
+    throw new HttpError(
+      'Fraction date must be after previous fraction.',
+      STATUS_CODE.BAD_REQUEST,
+    );
+  }
 
   const replacementUri = await fractie.replaceFractie(
     currentFractieId,

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -17,7 +17,7 @@ export const fractie = {
   addFractieOnPerson,
   addFractieOnPersonWithGraph,
   removeFractieWhenNoLidmaatschap,
-  isOrHasReplacement,
+  canReplaceFractie,
   replaceFractie,
 };
 
@@ -162,26 +162,21 @@ async function removeFractieWhenNoLidmaatschap(
   return fractieUris;
 }
 
-async function isOrHasReplacement(fractieId: string): Promise<boolean> {
+async function canReplaceFractie(fractieId: string): Promise<boolean> {
   const result = await query(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
 
-    SELECT ?object
+    SELECT ?endDate
     WHERE {
-     ?fractie mu:uuid ${sparqlEscapeString(fractieId)} .
-     VALUES ?p {
-       ext:endDate
-       dct:replaces
-     }
-     OPTIONAL {
-       ?fractie ?p ?object .
-     }
-    } LIMIT 1
+      ?fractie mu:uuid ${sparqlEscapeString(fractieId)} .
+      ?fractie ext:endDate ?endDate .
+     } LIMIT 1
   `);
+  const endDate = result.results.bindings[0]?.endDate?.value;
 
-  return !!result.results.bindings[0]?.object?.value;
+  return endDate ? false : true;
 }
 
 async function getGraphsOfFractie(fractieId: string): Promise<Array<string>> {

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -17,6 +17,7 @@ export const fractie = {
   addFractieOnPerson,
   addFractieOnPersonWithGraph,
   removeFractieWhenNoLidmaatschap,
+  isOrHasReplacement,
   replaceFractie,
 };
 
@@ -159,6 +160,28 @@ async function removeFractieWhenNoLidmaatschap(
   }
 
   return fractieUris;
+}
+
+async function isOrHasReplacement(fractieId: string): Promise<boolean> {
+  const result = await query(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX dct: <http://purl.org/dc/terms/>
+
+    SELECT ?object
+    WHERE {
+     ?fractie mu:uuid ${sparqlEscapeString(fractieId)} .
+     VALUES ?p {
+       ext:endDate
+       dct:replaces
+     }
+     OPTIONAL {
+       ?fractie ?p ?object .
+     }
+    } LIMIT 1
+  `);
+
+  return !!result.results.bindings[0]?.object?.value;
 }
 
 async function getGraphsOfFractie(fractieId: string): Promise<Array<string>> {

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -236,6 +236,8 @@ async function replaceFractie(
   const replacementUri = `http://data.lblod.info/id/fracties/${replacementFractieId}`;
   const replacement = sparqlEscapeUri(replacementUri);
   const replacementLabel = sparqlEscapeString(label);
+  const safeEndOfDay = sparqlEscapeDateTime(endOfDay(endDate));
+  const safeStartOfDay = sparqlEscapeDateTime(startOfDay(endDate));
 
   await updateSudo(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -251,9 +253,9 @@ async function replaceFractie(
     }
     INSERT {
       GRAPH ?g {
-        ?currentFractie ext:endDate ${sparqlEscapeDateTime(endOfDay(endDate))} .
+        ?currentFractie ext:endDate ${safeEndOfDay} .
         ${replacement} dct:replaces ?currentFractie .
-        ${replacement} ext:startDate ${sparqlEscapeDateTime(startOfDay(endDate))} .
+        ${replacement} ext:startDate ${safeStartOfDay} .
 
         ${replacement} a ?type .
         ${replacement} mu:uuid ${sparqlEscapeString(replacementFractieId)} .

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -258,7 +258,7 @@ async function replaceFractie(
         ${replacement} mu:uuid ${sparqlEscapeString(replacementFractieId)} .
         ${replacement} regorg:legalName ${replacementLabel} .
         ${replacement} org:memberOf ?bestuursorgaan .
-        ${replacement} org:linkedTo ?bestuurseenheid .
+        ${replacement} org:linkedTo ?gemeente .
         ${replacement} ext:isFractietype ?fractieType.
 
         ${replacement} dct:modified ?now .

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -206,9 +206,8 @@ async function replaceFractie(
 ): Promise<string> {
   const fractieUpdateGraphs = await getGraphsOfFractie(currentFractieId);
   const replacementFractieId = uuidv4();
-  const replacement = sparqlEscapeUri(
-    `http://data.lblod.info/id/fracties/${replacementFractieId}`,
-  );
+  const replacementUri = `http://data.lblod.info/id/fracties/${replacementFractieId}`;
+  const replacement = sparqlEscapeUri(replacementUri);
   const replacementLabel = sparqlEscapeString(label);
 
   await updateSudo(`
@@ -227,6 +226,7 @@ async function replaceFractie(
       GRAPH ?g {
         ?currentFractie ext:endDate ${sparqlEscapeDateTime(endDate)} .
         ${replacement} dct:replaces ?currentFractie .
+        ${replacement} ext:startDate ${sparqlEscapeDateTime(endDate)} .
 
         ${replacement} a ?type .
         ${replacement} mu:uuid ${sparqlEscapeString(replacementFractieId)} .
@@ -257,5 +257,5 @@ async function replaceFractie(
     }
   `);
 
-  return replacementFractieId;
+  return replacementUri;
 }

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { getSparqlResults } from '../util/sparql-result';
 import { FRACTIE_TYPE } from '../util/constants';
+import { endOfDay, startOfDay } from '../util/date-manipulation';
 import { TermProperty } from '../types';
 import moment from 'moment';
 
@@ -250,9 +251,9 @@ async function replaceFractie(
     }
     INSERT {
       GRAPH ?g {
-        ?currentFractie ext:endDate ${sparqlEscapeDateTime(endDate)} .
+        ?currentFractie ext:endDate ${sparqlEscapeDateTime(endOfDay(endDate))} .
         ${replacement} dct:replaces ?currentFractie .
-        ${replacement} ext:startDate ${sparqlEscapeDateTime(endDate)} .
+        ${replacement} ext:startDate ${sparqlEscapeDateTime(startOfDay(endDate))} .
 
         ${replacement} a ?type .
         ${replacement} mu:uuid ${sparqlEscapeString(replacementFractieId)} .

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -207,6 +207,7 @@ async function getGraphsOfFractie(fractieId: string): Promise<Array<string>> {
 async function replaceFractie(
   currentFractieId: string,
   label: string,
+  endDate: Date,
 ): Promise<string> {
   const fractieUpdateGraphs = await getGraphsOfFractie(currentFractieId);
   const replacementFractieId = uuidv4();
@@ -229,7 +230,7 @@ async function replaceFractie(
     }
     INSERT {
       GRAPH ?g {
-        ?currentFractie ext:endDate ?now .
+        ?currentFractie ext:endDate ${sparqlEscapeDateTime(endDate)} .
         ${replacement} dct:replaces ?currentFractie .
 
         ${replacement} a ?type .
@@ -238,6 +239,8 @@ async function replaceFractie(
         ${replacement} org:memberOf ?bestuursorgaan .
         ${replacement} org:linkedTo ?bestuurseenheid .
         ${replacement} ext:isFractietype ?fractieType.
+
+        ${replacement} dct:modified ?now .
         ?currentFractie dct:modified ?now .
       }
     }
@@ -247,7 +250,7 @@ async function replaceFractie(
       }
       GRAPH ?g {
         ?currentFractie a ?type .
-        ?currentFractie mu:uuid """673340D93B862019FED2B9B4""" .
+        ?currentFractie mu:uuid ${sparqlEscapeString(currentFractieId)} .
         ?currentFractie org:memberOf ?bestuursorgaan .
         ?currentFractie org:linkedTo ?gemeente .
         ?currentFractie ext:isFractietype ?fractieType .

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -16,6 +16,7 @@ export const fractie = {
   addFractieOnPerson,
   addFractieOnPersonWithGraph,
   removeFractieWhenNoLidmaatschap,
+  replaceFractie,
 };
 
 async function forBestuursperiode(
@@ -157,4 +158,12 @@ async function removeFractieWhenNoLidmaatschap(
   }
 
   return fractieUris;
+}
+
+async function replaceFractie(
+  currentFractieId: string,
+  bestuursperiodeId: string,
+  label: string,
+): Promise<string> {
+  return '<new fractie id>';
 }

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -859,21 +859,28 @@ async function bulkUpdateEndDate(
   const updateQuery = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX dct: <http://purl.org/dc/terms/>
-
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    
     DELETE {
-      ?mandataris mandaat:einde ?endDate.
-      ?mandataris dct:modified ?oldModified .
+      GRAPH ?g { 
+        ?mandataris mandaat:einde ?endDate.
+        ?mandataris dct:modified ?oldModified .
+      }
     }
     INSERT {
-      ?mandataris mandaat:einde ${escaped.endDate}.
-      ?mandataris dct:modified ?now .
+      GRAPH ?g {
+        ?mandataris mandaat:einde ${escaped.endDate}.
+        ?mandataris dct:modified ?now .
+      }
     }
     WHERE {
       VALUES ?mandataris {
         ${mandatarisUris.map((uri) => sparqlEscapeUri(uri)).join('\n')}
       }
-      ?mandataris a mandaat:Mandataris.
-
+      GRAPH ?g {
+        ?mandataris a mandaat:Mandataris.
+      }
+      ${asSudo ? '?g ext:ownedBy ?eenheid .' : ''}
       OPTIONAL {
         ?mandataris dct:modified ?oldModified .
       }

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -1036,7 +1036,8 @@ async function createNewMandatarissenForFractieReplacement(
   endDate: Date,
 ) {
   const e = {
-    endDate: sparqlEscapeDateTime(endDate),
+    mStartDate: sparqlEscapeDateTime(startOfDay(endDate)),
+    endDate: sparqlEscapeDateTime(endOfDay(endDate)),
     fractieId: sparqlEscapeString(fractieId),
     replacementUri: sparqlEscapeUri(replacementUri),
   };
@@ -1059,7 +1060,7 @@ async function createNewMandatarissenForFractieReplacement(
       GRAPH ?g {
         ?newMandataris a mandaat:Mandataris .
         ?newMandataris mu:uuid ?newMandatarisId .
-        ?newMandataris mandaat:start ${e.endDate} .
+        ?newMandataris mandaat:start ${e.mStartDate} .
         ?newMandataris mandaat:einde ?newMandatarisEndDate .
         ?newMandataris mandaat:isTijdelijkVervangenDoor ?vervanger .
         ?newMandataris org:holds ?mandaat .
@@ -1099,10 +1100,10 @@ async function createNewMandatarissenForFractieReplacement(
         }
 
         OPTIONAL {
-          ?newMandataris mandaat:beleidsdomein ?beleidsdomeinen .
+          ?mandataris mandaat:beleidsdomein ?beleidsdomeinen .
         }
         OPTIONAL {
-          ?newMandataris mandaat:rangorde ?rangorde .
+          ?mandataris mandaat:rangorde ?rangorde .
         }
 
         # generate new id's for uri's

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -1047,7 +1047,8 @@ async function createNewMandatarissenForFractieReplacement(
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-    
+    PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
+
     DELETE {
       GRAPH ?g {
         ?mandataris mandaat:einde ?mandatarisEinde .

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -1067,6 +1067,8 @@ async function createNewMandatarissenForFractieReplacement(
         ?newMandataris mandaat:isBestuurlijkeAliasVan ?persoon .
         ?newMandataris lmb:hasPublicationStatus <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188> . # Effectief
         ?newMandataris org:hasMembership ?newLidmaatschap .
+        ?newMandataris mandaat:beleidsdomein ?beleidsdomeinen .
+        ?newMandataris mandaat:rangorde ?rangorde .
 
         ?newLidmaatschap a org:Membership .
         ?newLidmaatschap mu:uuid ?newLidmaatschapId .
@@ -1094,6 +1096,13 @@ async function createNewMandatarissenForFractieReplacement(
         }
         OPTIONAL {
           ?mandataris dct:modified ?mandatarisModified .
+        }
+
+        OPTIONAL {
+          ?newMandataris mandaat:beleidsdomein ?beleidsdomeinen .
+        }
+        OPTIONAL {
+          ?newMandataris mandaat:rangorde ?rangorde .
         }
 
         # generate new id's for uri's

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -844,11 +844,7 @@ async function getActiveMandatarissenForPerson(
   return getSparqlResults(sparqlResult).map((b) => b.mandataris?.value);
 }
 
-async function bulkUpdateEndDate(
-  mandatarisUris: Array<string>,
-  endDate: Date,
-  asSudo = false,
-) {
+async function bulkUpdateEndDate(mandatarisUris: Array<string>, endDate: Date) {
   if (mandatarisUris.length === 0) {
     return;
   }
@@ -859,28 +855,21 @@ async function bulkUpdateEndDate(
   const updateQuery = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX dct: <http://purl.org/dc/terms/>
-    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-    
+
     DELETE {
-      GRAPH ?g { 
-        ?mandataris mandaat:einde ?endDate.
-        ?mandataris dct:modified ?oldModified .
-      }
+      ?mandataris mandaat:einde ?endDate.
+      ?mandataris dct:modified ?oldModified .
     }
     INSERT {
-      GRAPH ?g {
-        ?mandataris mandaat:einde ${escaped.endDate}.
-        ?mandataris dct:modified ?now .
-      }
+      ?mandataris mandaat:einde ${escaped.endDate}.
+      ?mandataris dct:modified ?now .
     }
     WHERE {
       VALUES ?mandataris {
         ${mandatarisUris.map((uri) => sparqlEscapeUri(uri)).join('\n')}
       }
-      GRAPH ?g {
-        ?mandataris a mandaat:Mandataris.
-      }
-      ${asSudo ? '?g ext:ownedBy ?eenheid .' : ''}
+      ?mandataris a mandaat:Mandataris.
+
       OPTIONAL {
         ?mandataris dct:modified ?oldModified .
       }
@@ -892,11 +881,7 @@ async function bulkUpdateEndDate(
       BIND(NOW() AS ?now)
     }
   `;
-  let queryMethod = query;
-  if (asSudo) {
-    queryMethod = querySudo;
-  }
-  await queryMethod(updateQuery);
+  await query(updateQuery);
 }
 
 export async function getReplacements(

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -844,7 +844,11 @@ async function getActiveMandatarissenForPerson(
   return getSparqlResults(sparqlResult).map((b) => b.mandataris?.value);
 }
 
-async function bulkUpdateEndDate(mandatarisUris: Array<string>, endDate: Date) {
+async function bulkUpdateEndDate(
+  mandatarisUris: Array<string>,
+  endDate: Date,
+  asSudo = false,
+) {
   if (mandatarisUris.length === 0) {
     return;
   }
@@ -881,7 +885,11 @@ async function bulkUpdateEndDate(mandatarisUris: Array<string>, endDate: Date) {
       BIND(NOW() AS ?now)
     }
   `;
-  await update(updateQuery);
+  let queryMethod = query;
+  if (asSudo) {
+    queryMethod = querySudo;
+  }
+  await queryMethod(updateQuery);
 }
 
 export async function getReplacements(

--- a/data-access/mandataris.ts
+++ b/data-access/mandataris.ts
@@ -352,7 +352,7 @@ export const createMandatarisInstance = async (
         mandaat:isBestuurlijkeAliasVan ${sparqlEscapeUri(persoonUri)} ;
         ${mandatarisRangorde}
         ${mandatarisBeleidsDomeinen}
-        mandaat:start 
+        mandaat:start
           ${sparqlEscapeDateTime(startOfDay(mandatarisStart, true))} ;
         mandaat:einde ${sparqlEscapeDateTime(endOfDay(mandatarisEnd, true))} ;
         org:holds ${sparqlEscapeUri(mandate.mandateUri)} ;
@@ -487,7 +487,7 @@ export async function endExistingMandataris(
     }
     INSERT {
       GRAPH ${sparqlEscapeUri(graph)} {
-        ?mandataris mandaat:einde 
+        ?mandataris mandaat:einde
           ${sparqlEscapeDateTime(endOfDay(endDate, true))} .
         ${extraTriples}
       }
@@ -1035,7 +1035,7 @@ async function createNewMandatarissenForFractieReplacement(
   replacementUri: string,
   endDate: Date,
 ) {
-  const e = {
+  const escaped = {
     mStartDate: sparqlEscapeDateTime(startOfDay(endDate)),
     endDate: sparqlEscapeDateTime(endOfDay(endDate)),
     fractieId: sparqlEscapeString(fractieId),
@@ -1054,13 +1054,13 @@ async function createNewMandatarissenForFractieReplacement(
       GRAPH ?g {
         ?mandataris mandaat:einde ?mandatarisEinde .
         ?mandataris dct:modified ?mandatarisModified .
-      } 
+      }
     }
     INSERT {
       GRAPH ?g {
         ?newMandataris a mandaat:Mandataris .
         ?newMandataris mu:uuid ?newMandatarisId .
-        ?newMandataris mandaat:start ${e.mStartDate} .
+        ?newMandataris mandaat:start ${escaped.mStartDate} .
         ?newMandataris mandaat:einde ?newMandatarisEndDate .
         ?newMandataris mandaat:isTijdelijkVervangenDoor ?vervanger .
         ?newMandataris org:holds ?mandaat .
@@ -1073,21 +1073,21 @@ async function createNewMandatarissenForFractieReplacement(
 
         ?newLidmaatschap a org:Membership .
         ?newLidmaatschap mu:uuid ?newLidmaatschapId .
-        ?newLidmaatschap org:organisation ${e.replacementUri}.
+        ?newLidmaatschap org:organisation ${escaped.replacementUri}.
 
-        ?mandataris mandaat:einde ${e.endDate} .
-      } 
+        ?mandataris mandaat:einde ${escaped.endDate} .
+      }
     }
     WHERE {
       GRAPH ?g {
         # identify
-        ?fractie mu:uuid ${e.fractieId} .
+        ?fractie mu:uuid ${escaped.fractieId} .
         ?mandataris org:hasMembership / org:organisation ?fractie .
 
         # copy over values
         ?mandataris org:holds ?mandaat .
         ?mandataris mandaat:status ?status .
-        ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon .      
+        ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon .
         OPTIONAL {
           ?mandataris mandaat:einde ?mandatarisEinde .
           BIND(strdt(CONCAT(?dateString, "T23:59:59Z"), xsd:dateTime) AS ?newMandatarisEndDate)
@@ -1111,7 +1111,7 @@ async function createNewMandatarissenForFractieReplacement(
         BIND(IRI(CONCAT("http://data.lblod.info/id/mandatarissen/", ?newMandatarisId)) AS ?newMandataris)
         BIND(SHA256(STR(?newMandatarisId)) AS ?newLidmaatschapId)
         BIND(IRI(CONCAT("http://data.lblod.info/id/lidmaatschappen/", ?newLidmaatschapId)) AS ?newLidmaatschap)
-        BIND(substr(STR(${e.endDate}), 1, 10) as ?dateString)
+        BIND(substr(STR(${escaped.endDate}), 1, 10) as ?dateString)
         BIND(strdt(CONCAT(?dateString, "T00:00:00Z"), xsd:dateTime) AS ?newMandatarisStartDate)
       }
       ?g ext:ownedBy ?eenheid .

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -6,6 +6,7 @@ services:
     labels:
       - logging=true
     environment:
+      TZ: Europe/Brussels
       NODE_ENV: development
       NO_BABEL_NODE: true
       EMAIL_FROM_MANDATARIS_WITHOUT_DECISION: 'lokaalmandatenbeheer@vlaanderen.be'

--- a/routes/fractie.ts
+++ b/routes/fractie.ts
@@ -93,11 +93,7 @@ fractiesRouter.post(
     const currentFractieId = req.params.fractieId;
 
     try {
-      await fractieUsecase.createReplacement(
-        currentFractieId,
-        req.body.bestuursperiodeId,
-        req.body.label,
-      );
+      await fractieUsecase.createReplacement(currentFractieId, req.body.label);
       return res.status(STATUS_CODE.CREATED).send();
     } catch (error) {
       const message =

--- a/routes/fractie.ts
+++ b/routes/fractie.ts
@@ -93,7 +93,11 @@ fractiesRouter.post(
     const currentFractieId = req.params.fractieId;
 
     try {
-      await fractieUsecase.createReplacement(currentFractieId, req.body.label);
+      await fractieUsecase.createReplacement(
+        currentFractieId,
+        req.body.label,
+        req.body.endDate,
+      );
       return res.status(STATUS_CODE.CREATED).send();
     } catch (error) {
       const message =

--- a/routes/fractie.ts
+++ b/routes/fractie.ts
@@ -88,21 +88,21 @@ fractiesRouter.delete(
 );
 
 fractiesRouter.post(
-  '/:fractieId/:bestuursperiodeId/create-replacement',
+  '/:fractieId/create-replacement',
   async (req: Request, res: Response) => {
     const currentFractieId = req.params.fractieId;
-    const bestuursperiodeId = req.params.bestuursperiodeId;
 
     try {
       await fractieUsecase.createReplacement(
         currentFractieId,
-        bestuursperiodeId,
+        req.body.bestuursperiodeId,
+        req.body.label,
       );
       return res.status(STATUS_CODE.CREATED).send();
     } catch (error) {
       const message =
         error.message ??
-        `Something went wrong while creating a replacement for fractie with id: ${currentFractieId} in bestuursperiode (${bestuursperiodeId})`;
+        `Something went wrong while creating a replacement for fractie with id: ${currentFractieId}`;
       const statusCode = error.status ?? STATUS_CODE.INTERNAL_SERVER_ERROR;
       return res.status(statusCode).send({ message: message });
     }

--- a/routes/fractie.ts
+++ b/routes/fractie.ts
@@ -102,7 +102,7 @@ fractiesRouter.post(
     } catch (error) {
       const message =
         error.message ??
-        `Something went wrong while creating a replacement for fractie with id: ${currentFractieId}`;
+        `Er liep iets mis bij het hernoemen van de huidige fractie met id: ${currentFractieId}`;
       const statusCode = error.status ?? STATUS_CODE.INTERNAL_SERVER_ERROR;
       return res.status(statusCode).send({ message: message });
     }

--- a/routes/fractie.ts
+++ b/routes/fractie.ts
@@ -86,3 +86,25 @@ fractiesRouter.delete(
     }
   },
 );
+
+fractiesRouter.post(
+  '/:fractieId/:bestuursperiodeId/create-replacement',
+  async (req: Request, res: Response) => {
+    const currentFractieId = req.params.fractieId;
+    const bestuursperiodeId = req.params.bestuursperiodeId;
+
+    try {
+      await fractieUsecase.createReplacement(
+        currentFractieId,
+        bestuursperiodeId,
+      );
+      return res.status(STATUS_CODE.CREATED).send();
+    } catch (error) {
+      const message =
+        error.message ??
+        `Something went wrong while creating a replacement for fractie with id: ${currentFractieId} in bestuursperiode (${bestuursperiodeId})`;
+      const statusCode = error.status ?? STATUS_CODE.INTERNAL_SERVER_ERROR;
+      return res.status(statusCode).send({ message: message });
+    }
+  },
+);


### PR DESCRIPTION
## Description

We want fractions to be editable. But when a fraction changes a new one should be created.

## How to test

1. The current fractie gets an `ext:endDate`
2. The replacement fractie gets a new relation to the old fraction with `dct:replaces`
3. All lidmaatschappen that had the old fraction connected have the new fraction 
4. All mandatarissen get a history item for this change with a message "CUSTOM"

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/460
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/603
