### PR TITLE
fix replacement not mirrored on create

### DIFF
--- a/controllers/linked-mandataris.ts
+++ b/controllers/linked-mandataris.ts
@@ -114,10 +114,17 @@ export const createLinkedMandataris = async (req) => {
   // no need to check for an existing mandate in ocmw (duplicate) the frontend already does so
   // AND validations will catch it
 
-  await handleCreationNewLinkedMandatarisAndPerson(
+  const linkedMandataris = await handleCreationNewLinkedMandatarisAndPerson(
     destinationGraph,
     userId,
     mandatarisId,
+  );
+
+  await handleReplacement(
+    destinationGraph,
+    userId,
+    mandatarisId,
+    linkedMandataris,
   );
 };
 


### PR DESCRIPTION
## Description

if the mandataris being created has a replacement, also mirror it to the ocmw
## How to test

create a mandataris that is verhinderd with a replacement. see that it is mirrored to the ocmw