### PR TITLE
refactor: when linking remove the existing one

### DIFF
--- a/cron/linking-mandatees.ts
+++ b/cron/linking-mandatees.ts
@@ -2,7 +2,6 @@ import { CronJob } from 'cron';
 import {
   getMandateIdsMissingLink,
   linkInstances,
-  unlinkInstance,
 } from '../data-access/linked-mandataris';
 import { getLinkedMandatesGemeenteToOcmw } from '../controllers/linked-mandataris';
 import { HttpError } from '../util/http-error';
@@ -40,7 +39,6 @@ export const cronjob = CronJob.from({
     try {
       for (let index = 0; index < ids.length; index++) {
         const id = ids[index];
-        await unlinkInstance(id.toBeLinkedMandataris);
         await linkInstances(id.mandataris, id.toBeLinkedMandataris);
       }
       console.log(`Linked ${ids.length} mandatees`);

--- a/cron/linking-mandatees.ts
+++ b/cron/linking-mandatees.ts
@@ -7,7 +7,7 @@ import { getLinkedMandatesGemeenteToOcmw } from '../controllers/linked-mandatari
 import { HttpError } from '../util/http-error';
 
 const LINKING_MANDATEES_CRON_PATTERN =
-  process.env.BESLUIT_CRON_PATTERN || '29 */4 * * * *'; // Every 4 minutes
+  process.env.LINKING_MANDATEES_CRON_PATTERN || '*/4 * * * *'; // Every 4 minutes
 const LINKING_MANDATEES_BATCH_SIZE =
   process.env.LINKING_MANDATEES_BATCH_SIZE || 250;
 let running = false;

--- a/cron/linking-mandatees.ts
+++ b/cron/linking-mandatees.ts
@@ -2,6 +2,7 @@ import { CronJob } from 'cron';
 import {
   getMandateIdsMissingLink,
   linkInstances,
+  unlinkInstance,
 } from '../data-access/linked-mandataris';
 import { getLinkedMandatesGemeenteToOcmw } from '../controllers/linked-mandataris';
 import { HttpError } from '../util/http-error';
@@ -39,6 +40,7 @@ export const cronjob = CronJob.from({
     try {
       for (let index = 0; index < ids.length; index++) {
         const id = ids[index];
+        await unlinkInstance(id.toBeLinkedMandataris);
         await linkInstances(id.mandataris, id.toBeLinkedMandataris);
       }
       console.log(`Linked ${ids.length} mandatees`);

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -632,11 +632,6 @@ export async function linkInstances(instance1: string, instance2: string) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 
-    DELETE {
-      GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
-        ?i1 ext:linked ?i2 .
-      }
-    }
     INSERT {
       GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
         ?i1 ext:linked ?i2 .

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -632,6 +632,11 @@ export async function linkInstances(instance1: string, instance2: string) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 
+    DELETE {
+      GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
+        ?i1 ext:linked ?i2 .
+      }
+    }
     INSERT {
       GRAPH <http://mu.semte.ch/graphs/linkedInstances> {
         ?i1 ext:linked ?i2 .

--- a/data-access/linked-mandataris.ts
+++ b/data-access/linked-mandataris.ts
@@ -628,6 +628,8 @@ export async function correctLinkedMandataris(
 }
 
 export async function linkInstances(instance1: string, instance2: string) {
+  await unlinkInstance(instance1);
+  await unlinkInstance(instance2);
   const insertQuery = `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>


### PR DESCRIPTION
Refs: lmb-1867

## Description

We need to remove the current link of mandate when linking a new so it does not have duplicate links

## How to test

1. Duplicate a current mandataris => it should not link a new mandate

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/180

## Attachments

- Created a new mandataris after deleted all **OK**
```bash
mandataris-1  | Headers set on SPARQL client: {"requestDefaults":{"headers":{"mu-auth-sudo":"true"}}}
mandataris-1  | Linked 1 mandatees
mandataris-1  |
