### PR TITLE
LMB-1914 | Can search over all legislatures

### DIFF
--- a/Requests/mandataris-download.ts
+++ b/Requests/mandataris-download.ts
@@ -1,20 +1,6 @@
 import { Request } from 'express';
 
-import { HttpError } from '../util/http-error';
-import { STATUS_CODE } from '../util/constants';
-
 export function mandatarisDownloadRequest(request: Request) {
-  const requiredParameters = ['bestuursperiodeId'];
-
-  requiredParameters.map((param) => {
-    if (!Object.keys(request.query).includes(param)) {
-      throw new HttpError(
-        `${param} is missing in the query parameters`,
-        STATUS_CODE.BAD_REQUEST,
-      );
-    }
-  });
-
   const {
     bestuursperiodeId,
     bestuursorgaanId,

--- a/controllers/fractie.ts
+++ b/controllers/fractie.ts
@@ -12,19 +12,9 @@ export const fractieUsecase = {
 };
 
 async function forBestuursperiode(
-  bestuursperiodeId: string,
+  bestuursperiodeId: string | undefined,
   onafhankelijk,
 ): Promise<Array<string>> {
-  const isBestuursperiode = await areIdsValid(RDF_TYPE.BESTUURSPERIODE, [
-    bestuursperiodeId,
-  ]);
-  if (!isBestuursperiode) {
-    throw new HttpError(
-      `Bestuursperiode with id ${bestuursperiodeId} not found.`,
-      STATUS_CODE.BAD_REQUEST,
-    );
-  }
-
   const fractieResult = await fractie.forBestuursperiode(
     bestuursperiodeId,
     onafhankelijk,

--- a/controllers/mandataris-download.ts
+++ b/controllers/mandataris-download.ts
@@ -36,14 +36,16 @@ async function validateQueryParams(queryParams) {
     fractieIds,
     bestuursFunctieCodeIds,
   } = queryParams;
-  const isBestuursperiode = await areIdsValid(RDF_TYPE.BESTUURSPERIODE, [
-    bestuursperiodeId,
-  ]);
-  if (!isBestuursperiode) {
-    throw new HttpError(
-      `Bestuursperiode with id ${bestuursperiodeId} not found.`,
-      STATUS_CODE.BAD_REQUEST,
-    );
+  if (bestuursperiodeId) {
+    const isBestuursperiode = await areIdsValid(RDF_TYPE.BESTUURSPERIODE, [
+      bestuursperiodeId,
+    ]);
+    if (!isBestuursperiode) {
+      throw new HttpError(
+        `Bestuursperiode with id ${bestuursperiodeId} not found.`,
+        STATUS_CODE.BAD_REQUEST,
+      );
+    }
   }
 
   if (bestuursorgaanId) {

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -29,20 +29,21 @@ export const fractie = {
 };
 
 async function forBestuursperiode(
-  bestuursperiodeId: string,
+  bestuursperiodeId: string | undefined,
   onafhankelijk,
 ): Promise<Array<TermProperty>> {
   const type = onafhankelijk
     ? FRACTIE_TYPE.ONAFHANKELIJK
     : FRACTIE_TYPE.SAMENWERKING;
-  let periodeById = `?bestuursperiode mu:uuid ${sparqlEscapeString(
-    bestuursperiodeId,
-  )}.`;
-  if (bestuursperiodeId === ALLE_BESTUURSPERIODE_ID) {
-    periodeById = `
+  let periodeById = `
       ?bestuursperiode mu:uuid ?periodId .
       filter (?periodId != ${sparqlEscapeString(OVERIGE_BESTUURSPERIODE_ID)})
     `;
+
+  if (!bestuursperiodeId) {
+    periodeById = `?bestuursperiode mu:uuid ${sparqlEscapeString(
+      bestuursperiodeId,
+    )}.`;
   }
 
   const getQuery = `

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -9,7 +9,11 @@ import { updateSudo, querySudo } from '@lblod/mu-auth-sudo';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getSparqlResults } from '../util/sparql-result';
-import { FRACTIE_TYPE } from '../util/constants';
+import {
+  ALLE_BESTUURSPERIODE_ID,
+  FRACTIE_TYPE,
+  OVERIGE_BESTUURSPERIODE_ID,
+} from '../util/constants';
 import { endOfDay, startOfDay } from '../util/date-manipulation';
 import { TermProperty } from '../types';
 import moment from 'moment';
@@ -31,6 +35,14 @@ async function forBestuursperiode(
   const type = onafhankelijk
     ? FRACTIE_TYPE.ONAFHANKELIJK
     : FRACTIE_TYPE.SAMENWERKING;
+  let periodeById = `mu:uuid ${sparqlEscapeString(bestuursperiodeId)}.`;
+  if (bestuursperiodeId === ALLE_BESTUURSPERIODE_ID) {
+    periodeById = `
+      mu:uuid ?periodId .
+      filter (?periodId != ${sparqlEscapeString(OVERIGE_BESTUURSPERIODE_ID)})
+    `;
+  }
+
   const getQuery = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -42,7 +54,7 @@ async function forBestuursperiode(
     SELECT DISTINCT ?fractieId
     WHERE {
       ?bestuursperiode a lmb:Bestuursperiode;
-        mu:uuid ${sparqlEscapeString(bestuursperiodeId)}.
+      ${periodeById}
       ?bestuursorgaan a besluit:Bestuursorgaan;
         lmb:heeftBestuursperiode ?bestuursperiode.
       ?fractie a mandaat:Fractie;

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -9,11 +9,7 @@ import { updateSudo, querySudo } from '@lblod/mu-auth-sudo';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getSparqlResults } from '../util/sparql-result';
-import {
-  ALLE_BESTUURSPERIODE_ID,
-  FRACTIE_TYPE,
-  OVERIGE_BESTUURSPERIODE_ID,
-} from '../util/constants';
+import { FRACTIE_TYPE } from '../util/constants';
 import { endOfDay, startOfDay } from '../util/date-manipulation';
 import { TermProperty } from '../types';
 import moment from 'moment';
@@ -35,11 +31,8 @@ async function forBestuursperiode(
   const type = onafhankelijk
     ? FRACTIE_TYPE.ONAFHANKELIJK
     : FRACTIE_TYPE.SAMENWERKING;
-  let periodeById = `
-      ?bestuursperiode mu:uuid ?periodId .
-      filter (?periodId != ${sparqlEscapeString(OVERIGE_BESTUURSPERIODE_ID)})
-    `;
 
+  let periodeById = '?bestuursperiode mu:uuid ?periodId .';
   if (!bestuursperiodeId) {
     periodeById = `?bestuursperiode mu:uuid ${sparqlEscapeString(
       bestuursperiodeId,

--- a/data-access/fractie.ts
+++ b/data-access/fractie.ts
@@ -35,10 +35,12 @@ async function forBestuursperiode(
   const type = onafhankelijk
     ? FRACTIE_TYPE.ONAFHANKELIJK
     : FRACTIE_TYPE.SAMENWERKING;
-  let periodeById = `mu:uuid ${sparqlEscapeString(bestuursperiodeId)}.`;
+  let periodeById = `?bestuursperiode mu:uuid ${sparqlEscapeString(
+    bestuursperiodeId,
+  )}.`;
   if (bestuursperiodeId === ALLE_BESTUURSPERIODE_ID) {
     periodeById = `
-      mu:uuid ?periodId .
+      ?bestuursperiode mu:uuid ?periodId .
       filter (?periodId != ${sparqlEscapeString(OVERIGE_BESTUURSPERIODE_ID)})
     `;
   }
@@ -53,7 +55,7 @@ async function forBestuursperiode(
 
     SELECT DISTINCT ?fractieId
     WHERE {
-      ?bestuursperiode a lmb:Bestuursperiode;
+      ?bestuursperiode a lmb:Bestuursperiode .
       ${periodeById}
       ?bestuursorgaan a besluit:Bestuursorgaan;
         lmb:heeftBestuursperiode ?bestuursperiode.

--- a/data-access/mandataris-download.ts
+++ b/data-access/mandataris-download.ts
@@ -1,7 +1,6 @@
 import { query, sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import { getSparqlResults } from '../util/sparql-result';
 import { queryResultToJson } from '../util/json-to-csv';
-import { OVERIGE_BESTUURSPERIODE_ID } from '../util/constants';
 
 export const downloadMandatarissen = {
   getUrisForFilters,
@@ -57,11 +56,8 @@ async function getUrisForFilters(filters) {
       ?bestuursfunctieCode mu:uuid ?functieCode.
     `;
   }
-  let periodeById = `
-      ?bestuursperiode mu:uuid ?periodId .
-      filter (?periodId != ${sparqlEscapeString(OVERIGE_BESTUURSPERIODE_ID)})
-    `;
 
+  let periodeById = '?bestuursperiode mu:uuid ?periodId .';
   if (bestuursperiodeId) {
     periodeById = `?bestuursperiode mu:uuid ${sparqlEscapeString(
       bestuursperiodeId,

--- a/data-access/mandataris-download.ts
+++ b/data-access/mandataris-download.ts
@@ -1,10 +1,7 @@
 import { query, sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import { getSparqlResults } from '../util/sparql-result';
 import { queryResultToJson } from '../util/json-to-csv';
-import {
-  ALLE_BESTUURSPERIODE_ID,
-  OVERIGE_BESTUURSPERIODE_ID,
-} from '../util/constants';
+import { OVERIGE_BESTUURSPERIODE_ID } from '../util/constants';
 
 export const downloadMandatarissen = {
   getUrisForFilters,
@@ -60,14 +57,15 @@ async function getUrisForFilters(filters) {
       ?bestuursfunctieCode mu:uuid ?functieCode.
     `;
   }
-  let periodeById = `?bestuursperiode mu:uuid ${sparqlEscapeString(
-    bestuursperiodeId,
-  )}.`;
-  if (bestuursperiodeId === ALLE_BESTUURSPERIODE_ID) {
-    periodeById = `
-        ?bestuursperiode mu:uuid ?periodId .
-        filter (?periodId != ${sparqlEscapeString(OVERIGE_BESTUURSPERIODE_ID)})
-      `;
+  let periodeById = `
+      ?bestuursperiode mu:uuid ?periodId .
+      filter (?periodId != ${sparqlEscapeString(OVERIGE_BESTUURSPERIODE_ID)})
+    `;
+
+  if (bestuursperiodeId) {
+    periodeById = `?bestuursperiode mu:uuid ${sparqlEscapeString(
+      bestuursperiodeId,
+    )}.`;
   }
 
   const queryString = `

--- a/data-access/mandataris-download.ts
+++ b/data-access/mandataris-download.ts
@@ -1,6 +1,10 @@
 import { query, sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import { getSparqlResults } from '../util/sparql-result';
 import { queryResultToJson } from '../util/json-to-csv';
+import {
+  ALLE_BESTUURSPERIODE_ID,
+  OVERIGE_BESTUURSPERIODE_ID,
+} from '../util/constants';
 
 export const downloadMandatarissen = {
   getUrisForFilters,
@@ -56,6 +60,15 @@ async function getUrisForFilters(filters) {
       ?bestuursfunctieCode mu:uuid ?functieCode.
     `;
   }
+  let periodeById = `?bestuursperiode mu:uuid ${sparqlEscapeString(
+    bestuursperiodeId,
+  )}.`;
+  if (bestuursperiodeId === ALLE_BESTUURSPERIODE_ID) {
+    periodeById = `
+        ?bestuursperiode mu:uuid ?periodId .
+        filter (?periodId != ${sparqlEscapeString(OVERIGE_BESTUURSPERIODE_ID)})
+      `;
+  }
 
   const queryString = `
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
@@ -73,7 +86,7 @@ async function getUrisForFilters(filters) {
       ?mandataris org:holds ?mandaat.
 
       ?bestuursorgaan lmb:heeftBestuursperiode ?bestuursperiode.
-      ?bestuursperiode mu:uuid ${sparqlEscapeString(bestuursperiodeId)}.
+      ${periodeById}
 
       ${bestuursorgaanInTijdFilter ?? ''}
       ${onlyActiveFilter ?? ''}

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -48,6 +48,3 @@ export const AANGEWEZEN_BURGEMEESTER_FUNCTIE_CODE =
 
 export const PUBLIC_GRAPH_URI =
   process.env.PUBLIC_GRAPH_URI || 'http://mu.semte.ch/graphs/public';
-
-export const OVERIGE_BESTUURSPERIODE_ID =
-  '9486222f-2696-4811-bde1-fef9dc4b5f68';

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -51,4 +51,3 @@ export const PUBLIC_GRAPH_URI =
 
 export const OVERIGE_BESTUURSPERIODE_ID =
   '9486222f-2696-4811-bde1-fef9dc4b5f68';
-export const ALLE_BESTUURSPERIODE_ID = '3faeb4c3-c4d7-47ea-b449-61579092a200';

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -48,3 +48,7 @@ export const AANGEWEZEN_BURGEMEESTER_FUNCTIE_CODE =
 
 export const PUBLIC_GRAPH_URI =
   process.env.PUBLIC_GRAPH_URI || 'http://mu.semte.ch/graphs/public';
+
+export const OVERIGE_BESTUURSPERIODE_ID =
+  '9486222f-2696-4811-bde1-fef9dc4b5f68';
+export const ALLE_BESTUURSPERIODE_ID = '3faeb4c3-c4d7-47ea-b449-61579092a200';


### PR DESCRIPTION
## Description

Some call are done in this service with the bestuursperiode id. As we now added the ALLE bestuursperiode concept scheme option we need to handle this here as well.

## How to test

1. When a bestuursperiode id is used and it equals to the ALLE option we filter on not overige instead of the given id
2. fractie route updated
3. persoon route should be fine for the used bestuursperiode context
4. Downloading of mandatarissen with the all filter is possible

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/503
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/636

Export of all filter
<img width="2027" height="497" alt="image" src="https://github.com/user-attachments/assets/9f6f5c9e-64f9-4f4a-b90b-2aae17103447" />

